### PR TITLE
rebrand: Aura -> Nova

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Aura
+# Nova
 
-Aura is an AI team member that lives in Slack -- a persistent, autonomous colleague with memory, judgment, and the ability to act.
+Nova is an AI team member (forked from Aura) that lives in Slack -- a persistent, autonomous colleague with memory, judgment, and the ability to act.
 
 She reads context, remembers every conversation, initiates work without being asked, and gets smarter over time. She has persistent memory, a self-improvement loop, and the ability to act autonomously: file issues, make phone calls, send emails, query data warehouses, run code, dispatch coding agents, and more -- all without leaving your workspace.
 
@@ -38,7 +38,7 @@ Built with TypeScript, Hono, Vercel serverless functions, Vercel AI SDK v6, and 
 
 **Memory** — After every exchange, facts, decisions, and open threads are extracted, embedded, and stored. Semantic search over all past conversations.
 
-**Jobs** — Scheduled and recurring tasks with cron execution, playbooks, and retry logic. Aura creates jobs for herself when she spots recurring work.
+**Jobs** — Scheduled and recurring tasks with cron execution, playbooks, and retry logic. Nova creates jobs for itself when she spots recurring work.
 
 ---
 
@@ -123,12 +123,12 @@ Each integration degrades gracefully if unconfigured — missing keys disable fe
 
 ## Troubleshooting
 
-**Aura doesn't respond to DMs**
+**Nova doesn't respond to DMs**
 - Check that `im:history` and `im:read` scopes are added and `message.im` event subscription is enabled
 - Verify `AURA_BOT_USER_ID` matches the bot's actual Slack user ID
 
-**Aura doesn't respond to @mentions**
-- Invite Aura to the channel first (`/invite @Aura`)
+**Nova doesn't respond to @mentions**
+- Invite Nova to the channel first (`/invite @Nova`)
 - Check that `app_mention` event subscription is enabled
 
 **LLM calls fail**

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "aura",
+  "name": "nova",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/src/app.ts
+++ b/src/app.ts
@@ -57,7 +57,7 @@ export const app = new Hono();
 // Health check
 app.get("/", (c) => {
   return c.json({
-    name: "Aura",
+    name: "Nova",
     version: "0.1.0",
     status: "alive",
   });
@@ -777,7 +777,7 @@ app.get("/api/oauth/google/auth-url", async (c) => {
     url,
     instructions: userId
       ? `Open this URL in a browser logged in as the Gmail account for Slack user ${userId}`
-      : "Open this URL in a browser logged in as your Aura email account",
+      : "Open this URL in a browser logged in as your Nova email account",
   });
 });
 

--- a/src/cron/execute-job.ts
+++ b/src/cron/execute-job.ts
@@ -18,7 +18,7 @@ const RETRY_DELAY_MS = 30 * 60 * 1000;
 
 // ── System Prompts ───────────────────────────────────────────────────────────
 
-const JOB_SYSTEM_PROMPT = `You are Aura executing a job autonomously. You have full access to your tools.
+const JOB_SYSTEM_PROMPT = `You are Nova executing a job autonomously. You have full access to your tools.
 
 Rules:
 - Execute the task described below. Use your tools to read channels, post messages, look up users, etc.
@@ -32,7 +32,7 @@ Rules:
 - Be concise. Digests and summaries, not essays.
 - Do NOT respond conversationally. Just execute the task and report.`;
 
-const CONTINUATION_SYSTEM_PROMPT = `You are Aura resuming a multi-step task. Your accumulated progress and context are below.
+const CONTINUATION_SYSTEM_PROMPT = `You are Nova resuming a multi-step task. Your accumulated progress and context are below.
 
 Rules:
 - Continue from where you left off. The plan note contains your progress, next steps, and context.

--- a/src/db/seed-skills.ts
+++ b/src/db/seed-skills.ts
@@ -1,7 +1,7 @@
 /**
  * Seed initial skill notes.
  *
- * Run after migration to bootstrap Aura's core playbooks.
+ * Run after migration to bootstrap Nova's core playbooks.
  * Idempotent: only inserts skills that don't already exist.
  *
  * Usage: tsx src/db/seed-skills.ts

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Aura v0 — Entry point
+ * Nova v0 — Entry point
  *
  * For local development: runs the Hono app on port 3000.
  * For Vercel: the app is exported from app.ts and used by the API route.
@@ -13,7 +13,7 @@ const port = parseInt(process.env.PORT || "3000");
 if (process.env.NODE_ENV !== "production") {
   const { serve } = await import("@hono/node-server");
   serve({ fetch: app.fetch, port }, () => {
-    console.log(`\n  🔮 Aura is listening on http://localhost:${port}\n`);
+    console.log(`\n  🔮 Nova is listening on http://localhost:${port}\n`);
   });
 }
 

--- a/src/lib/gmail.ts
+++ b/src/lib/gmail.ts
@@ -73,7 +73,7 @@ const SCOPES = [
 
 const EMAIL_SIGNATURE_HTML = `
 <div style="margin-top: 24px; padding-top: 16px; border-top: 1px solid #e0e0e0; font-family: Arial, sans-serif; font-size: 13px; color: #666;">
-  <strong style="color: #333;">Aura</strong> &middot; AI Team Member<br/>
+  <strong style="color: #333;">Nova</strong> &middot; AI Team Member<br/>
   <a href="${process.env.AURA_WEBSITE_URL || ''}" style="color: #0066cc; text-decoration: none;">${process.env.COMPANY_NAME || 'Aura'}</a>
 </div>`.trim();
 
@@ -110,7 +110,7 @@ async function createBaseOAuth2Client() {
 
 /**
  * Get an authenticated OAuth2Client for a given user.
- * No args = Aura's own token (U0AFEC1C69F). Pass a userId for per-user tokens.
+ * No args = Nova's own token (U0AFEC1C69F). Pass a userId for per-user tokens.
  */
 export async function getOAuth2Client(userId?: string) {
   const resolvedUserId = userId || process.env.AURA_BOT_USER_ID || "aura";
@@ -125,7 +125,7 @@ export async function getOAuth2Client(userId?: string) {
 }
 
 /**
- * Returns an authenticated Gmail client for Aura, or null if credentials are missing.
+ * Returns an authenticated Gmail client for Nova, or null if credentials are missing.
  */
 export async function getGmailClient() {
   const auth = await getOAuth2Client();
@@ -403,7 +403,7 @@ function extractAttachments(
 // ── Public API ──────────────────────────────────────────────────────────────
 
 /**
- * Send an email as a specific user (or Aura by default).
+ * Send an email as a specific user (or Nova by default).
  * When userId is provided, uses getGmailClientForUser(); otherwise falls back to getGmailClient().
  */
 export async function sendEmail(
@@ -462,7 +462,7 @@ export async function sendEmail(
   };
 }
 
-// ── Shared helpers (DRY: used by both Aura and user-facing functions) ───────
+// ── Shared helpers (DRY: used by both Nova and user-facing functions) ───────
 
 async function listEmailsWithClient(
   gmailClient: any,
@@ -712,7 +712,7 @@ export interface DraftSummary {
 
 /**
  * Get a refresh token for a specific Slack user from the oauth_tokens table.
- * Returns null if the user has not authorized Aura.
+ * Returns null if the user has not authorized Nova.
  */
 export async function getUserRefreshToken(
   userId: string,

--- a/src/memory/extract.ts
+++ b/src/memory/extract.ts
@@ -148,7 +148,7 @@ const extractedMemoriesSchema = z.object({
       shareable: z
         .boolean()
         .describe(
-          "True only if the user explicitly asked Aura to share this info with someone specific",
+          "True only if the user explicitly asked Nova to share this info with someone specific",
         )
         .default(false),
     }),
@@ -173,8 +173,8 @@ Types of memories to extract:
 Rules:
 - Be concise — each memory should be one clear sentence.
 - Include the person's name or Slack user ID when relevant.
-- Don't extract things Aura already knows (if they're in the context).
-- If the user explicitly asks Aura to tell someone something, mark that memory as shareable.
+- Don't extract things Nova already knows (if they're in the context).
+- If the user explicitly asks Nova to tell someone something, mark that memory as shareable.
 - Return an empty array if there's nothing worth remembering.`;
 
 interface ExtractionContext {
@@ -194,7 +194,7 @@ export async function extractMemories(context: ExtractionContext): Promise<void>
   const start = Date.now();
 
   try {
-    const conversationText = `User (${context.displayName || context.userId}): ${context.userMessage}\n\nAura: ${context.assistantResponse}`;
+    const conversationText = `User (${context.displayName || context.userId}): ${context.userMessage}\n\nNova: ${context.assistantResponse}`;
 
     const model = await getFastModel();
 

--- a/src/memory/transparency.ts
+++ b/src/memory/transparency.ts
@@ -13,7 +13,7 @@ import { embedText } from "../lib/embeddings.js";
  */
 
 /**
- * Get everything Aura knows about a user — their profile and all memories
+ * Get everything Nova knows about a user — their profile and all memories
  * where they appear in relatedUserIds.
  */
 export async function getKnowledgeAboutUser(

--- a/src/personality/system-prompt.ts
+++ b/src/personality/system-prompt.ts
@@ -40,10 +40,10 @@ interface SystemPromptContext {
 }
 
 /**
- * Aura's base personality — the soul of the system.
+ * Nova's base personality — the soul of the system.
  * Version-controlled. Changes are deliberate.
  */
-const PERSONALITY = `You are Aura -- a team member, not a tool. You exist as a single, shared colleague that everyone on the team knows and interacts with. You remember every conversation you've ever had with anyone on the team.
+const PERSONALITY = `You are Nova -- a team member, not a tool. You exist as a single, shared colleague that everyone on the team knows and interacts with. You remember every conversation you've ever had with anyone on the team.
 
 ## Core drive
 
@@ -168,7 +168,7 @@ Understanding this helps you set realistic expectations, debug failures, and rea
 
 **Heartbeat:** Every 30 minutes. One-shots fire at scheduled time. Recurring jobs evaluate cron + frequency limits. Each execution gets up to 350 tool calls. Scheduling granularity is ~30 minutes. Failed jobs retry 3x with 30-min backoff, then escalate via DM.
 
-**Codebase:** Your source is at github.com/AuraHQ-ai/aura. You have Claude Code (\`claude\`) in your sandbox for exploration, review, and code changes. Always create PRs on branches, never push to main. For prompt changes, flag as "self-edit" and explain reasoning.
+**Codebase:** Your source is at github.com/wieseljonas/nova (forked from AuraHQ-ai/aura). You have Claude Code (\`claude\`) in your sandbox for exploration, review, and code changes. Always create PRs on branches, never push to main. For prompt changes, flag as "self-edit" and explain reasoning.
 
 **Limits:** You can't access authenticated external APIs directly from runtime. But you can run code, shell commands, and CLI tools in the sandbox, and search the web / read URLs.
 
@@ -184,7 +184,7 @@ You have tools for Slack, email, calendar, BigQuery, notes, jobs, web, sandbox, 
 **Channel access:**
 - You must join a channel before reading or posting. Use join_channel first.
 - list_channels only shows channels you've already joined -- many public channels exist beyond that list.
-- Private channels require someone to \`/invite @Aura\`. You can only self-join public channels.
+- Private channels require someone to \`/invite @Nova\`. You can only self-join public channels.
 - You can only edit or delete your own messages.
 
 **DM privacy:**
@@ -345,7 +345,7 @@ function formatConversations(conversations: ConversationThread[]): string {
       const msgs = capped
         .map((m) => {
           const timeAgo = relativeTime(new Date(m.createdAt));
-          const speaker = m.role === "assistant" ? "Aura" : m.userId;
+          const speaker = m.role === "assistant" ? "Nova" : m.userId;
           return `  ${speaker} (${timeAgo}): ${m.content.length > 800 ? m.content.substring(0, 800) + "…" : m.content}`;
         })
         .join("\n");

--- a/src/pipeline/context.ts
+++ b/src/pipeline/context.ts
@@ -68,9 +68,9 @@ export interface MessageContext {
   messageTs: string;
   /** Whether this is a DM */
   isDm: boolean;
-  /** Whether Aura was explicitly mentioned (@Aura) */
+  /** Whether Nova was explicitly mentioned (@Nova) */
   isMentioned: boolean;
-  /** Whether Aura was addressed by name */
+  /** Whether Nova was addressed by name */
   isAddressedByName: boolean;
   /** When set, this message is a Slackbot notification about a Slack List item */
   slackListItemContext?: SlackListItemContext;
@@ -131,12 +131,12 @@ export function buildMessageContext(
   // Determine channel type
   const channelType = resolveChannelType(event);
 
-  // Check if Aura was mentioned
+  // Check if Nova was mentioned
   const mentionPattern = new RegExp(`<@${botUserId}>`, "g");
   const isMentioned = mentionPattern.test(text);
 
-  // Check if addressed by name (case-insensitive "Aura" at start or "Aura," anywhere)
-  const isAddressedByName = /\baura[,:]?\s/i.test(text) || /\baura[?!.]?\s*$/i.test(text);
+  // Check if addressed by name (case-insensitive "Nova" at start or "Nova," anywhere)
+  const isAddressedByName = /\bnova[,:]?\s/i.test(text) || /\bnova[?!.]?\s*$/i.test(text);
 
   // Strip the @mention from the text
   const cleanText = text.replace(mentionPattern, "").trim();
@@ -170,23 +170,23 @@ export interface ShouldRespondResult {
 
 
 /**
- * Determine if Aura should respond to this message (Tiers 2–4).
+ * Determine if Nova should respond to this message (Tiers 2–4).
  *
  * Tier 1 (DMs, explicit @mention, addressed by name) is handled inline
  * by the pipeline before this function is called — see `runPipeline` in
  * `index.ts`. This function is only invoked when Tier 1 did NOT match.
  *
  * Tiers handled here:
- * 2. LLM gate: Aura is a thread participant or it's her thread (fail-open)
- * 3. LLM gate: Aura posted recently in the channel (fail-closed)
- * 4. Cold observation: Aura monitors but hasn't been active (fail-closed, high bar)
+ * 2. LLM gate: Nova is a thread participant or it's their thread (fail-open)
+ * 3. LLM gate: Nova posted recently in the channel (fail-closed)
+ * 4. Cold observation: Nova monitors but hasn't been active (fail-closed, high bar)
  */
 export async function shouldRespond(
   context: MessageContext,
   conversation: ConversationContext,
   alwaysProcessChannels: Set<string>,
 ): Promise<ShouldRespondResult> {
-  // Tier 2: Aura is a thread participant or it's her thread
+  // Tier 2: Nova is a thread participant or it's their thread
   if (conversation.isAuraParticipant || conversation.isAuraThread) {
     const shouldReply = await llmShouldRespond(context, conversation, true);
     return {
@@ -195,7 +195,7 @@ export async function shouldRespond(
     };
   }
 
-  // Tier 3: Aura posted recently in the channel (non-threaded)
+  // Tier 3: Nova posted recently in the channel (non-threaded)
   if (conversation.auraRecentlyActive) {
     const shouldReply = await llmShouldRespond(context, conversation, false);
     return {
@@ -209,7 +209,7 @@ export async function shouldRespond(
     return { respond: true, reason: "always_process_channel" };
   }
 
-  // Tier 4: Cold observation — Aura is in the channel but hasn't been active.
+  // Tier 4: Cold observation — Nova is in the channel but hasn't been active.
   // Use a conservative LLM gate (fail-closed, high bar).
   const shouldReply = await llmShouldRespond(context, conversation, false, true);
   return {
@@ -220,52 +220,52 @@ export async function shouldRespond(
 
 // ── LLM Gate ─────────────────────────────────────────────────────────────────
 
-const SHOULD_RESPOND_PROMPT_PARTICIPANT = `You are deciding whether Aura (a Slack bot and team assistant) should respond to the latest message.
+const SHOULD_RESPOND_PROMPT_PARTICIPANT = `You are deciding whether Nova (a Slack bot and team assistant) should respond to the latest message.
 
-Aura is already a participant in this conversation (she has sent messages before).
+Nova is already a participant in this conversation (they have sent messages before).
 
 Rules:
-- Answer RESPOND if the message asks a question, requests an action, continues a conversation that needs Aura's input, shares information Aura should acknowledge, or is clearly directed at Aura.
+- Answer RESPOND if the message asks a question, requests an action, continues a conversation that needs Nova's input, shares information Nova should acknowledge, or is clearly directed at Nova.
 - Answer SKIP if the message is just an acknowledgment (thanks, ok, got it, thumbs up), is directed at someone else, or is something where responding would add nothing.
 - When in doubt, lean toward RESPOND — it's better to be helpful than to ignore someone.
 
 Answer with a single word: RESPOND or SKIP.`;
 
-const SHOULD_RESPOND_PROMPT_RECENTLY_ACTIVE = `You are deciding whether Aura (a Slack bot and team assistant) should respond to the latest message.
+const SHOULD_RESPOND_PROMPT_RECENTLY_ACTIVE = `You are deciding whether Nova (a Slack bot and team assistant) should respond to the latest message.
 
-Aura has been active in this channel recently, but is NOT necessarily a participant in this specific conversation or thread.
+Nova has been active in this channel recently, but is NOT necessarily a participant in this specific conversation or thread.
 
 Rules:
-- Answer RESPOND if the message asks a question, requests an action, shares information Aura should acknowledge, or is clearly directed at Aura.
-- Answer SKIP if the message is just an acknowledgment (thanks, ok, got it, thumbs up), is directed at someone else, is part of an ongoing conversation between other people that Aura is not involved in, or is something where responding would add nothing.
-- When in doubt, lean toward SKIP — Aura should not intrude on conversations she's not part of.
+- Answer RESPOND if the message asks a question, requests an action, shares information Nova should acknowledge, or is clearly directed at Nova.
+- Answer SKIP if the message is just an acknowledgment (thanks, ok, got it, thumbs up), is directed at someone else, is part of an ongoing conversation between other people that Nova is not involved in, or is something where responding would add nothing.
+- When in doubt, lean toward SKIP — Nova should not intrude on conversations she's not part of.
 
 Answer with a single word: RESPOND or SKIP.`;
 
-const SHOULD_RESPOND_PROMPT_COLD_OBSERVATION = `You are deciding whether Aura (a Slack bot and team assistant) should respond to this message in a channel she monitors but hasn't recently participated in.
+const SHOULD_RESPOND_PROMPT_COLD_OBSERVATION = `You are deciding whether Nova (a Slack bot and team assistant) should respond to this message in a channel she monitors but hasn't recently participated in.
 
-This is COLD observation — Aura is passively watching. The bar to respond is HIGH.
+This is COLD observation — Nova is passively watching. The bar to respond is HIGH.
 
 Answer RESPOND only if:
 - Someone is reporting a bug, error, or something broken
 - There's an urgent issue that needs immediate attention
-- Someone is explicitly asking a question Aura could answer (data, metrics, status)
-- The message directly relates to Aura's active work (bug triage, OKRs, team ops)
+- Someone is explicitly asking a question Nova could answer (data, metrics, status)
+- The message directly relates to Nova's active work (bug triage, OKRs, team ops)
 
 Answer SKIP for:
 - General conversation, banter, casual chat
 - Messages directed at specific people
 - Status updates that don't need a response
-- Anything where Aura jumping in uninvited would be annoying
+- Anything where Nova jumping in uninvited would be annoying
 
 When in doubt, SKIP. Being quiet is better than being noisy.
 
 Answer with a single word: RESPOND or SKIP.`;
 
 /**
- * Ask the fast model (Haiku) whether Aura should respond to a message.
+ * Ask the fast model (Haiku) whether Nova should respond to a message.
  *
- * @param isParticipant - true if Aura is a direct participant in this thread/conversation (Tier 2),
+ * @param isParticipant - true if Nova is a direct participant in this thread/conversation (Tier 2),
  *   false if she's only recently active in the channel (Tier 3) or cold-observing (Tier 4).
  * @param coldObservation - true for Tier 4 cold observation (highest bar, most conservative).
  *
@@ -301,7 +301,7 @@ async function llmShouldRespond(
         ? SHOULD_RESPOND_PROMPT_PARTICIPANT
         : SHOULD_RESPOND_PROMPT_RECENTLY_ACTIVE;
 
-    const userMessage = `Recent conversation:\n${conversationText}\n\nLatest message from ${senderName}:\n${context.text}\n\nShould Aura respond?`;
+    const userMessage = `Recent conversation:\n${conversationText}\n\nLatest message from ${senderName}:\n${context.text}\n\nShould Nova respond?`;
 
     const model = await getFastModel();
     const result = await generateText({

--- a/src/pipeline/index.ts
+++ b/src/pipeline/index.ts
@@ -223,7 +223,7 @@ export async function runPipeline(options: PipelineOptions): Promise<void> {
     }
 
     // Set assistant thread status — triggers the shimmer animation on
-    // Aura's name and shows a loading indicator while processing.
+    // Nova's name and shows a loading indicator while processing.
     // Requires the `assistant:write` scope (enabled via Agents & AI Apps
     // toggle in Slack app settings). Status auto-clears on reply.
     try {
@@ -562,7 +562,7 @@ async function runBackgroundTasks(params: {
       metadata: buildMessageMetadata(event),
     });
 
-    // Store Aura's response with a pseudo-timestamp
+    // Store Nova's response with a pseudo-timestamp
     const assistantTs = `${context.messageTs}-aura`;
     await storeMessage({
       slackTs: assistantTs,

--- a/src/pipeline/prompt.ts
+++ b/src/pipeline/prompt.ts
@@ -96,7 +96,7 @@ export async function assemblePrompt(
   ]);
 
   // Format conversation context from live Slack data (already fetched by pipeline).
-  // Include channel-history fallback for DMs, threaded messages, and when Aura
+  // Include channel-history fallback for DMs, threaded messages, and when Nova
   // is recently active in the channel (Tier 3) — otherwise the response LLM
   // would have no conversation context despite the shouldRespond gate seeing it.
   const useChannelFallback =

--- a/src/pipeline/slack-context.ts
+++ b/src/pipeline/slack-context.ts
@@ -44,11 +44,11 @@ export interface ConversationContext {
   thread: SlackThreadMessage[] | null;
   /** Recent top-level channel/DM messages (for non-threaded context). */
   recentMessages: SlackThreadMessage[];
-  /** Whether Aura has replied in the current thread. */
+  /** Whether Nova has replied in the current thread. */
   isAuraParticipant: boolean;
-  /** Whether the thread parent message is Aura's. */
+  /** Whether the thread parent message is Nova's. */
   isAuraThread: boolean;
-  /** Whether Aura posted recently in the channel (within 1h, for non-threaded context). */
+  /** Whether Nova posted recently in the channel (within 1h, for non-threaded context). */
   auraRecentlyActive: boolean;
 }
 
@@ -182,7 +182,7 @@ export async function fetchConversationContext(
         const userId = msg.user || msg.bot_id || "unknown";
         const isBot = msg.user === botUserId;
         const { name: displayName } = isBot
-          ? { name: "Aura" }
+          ? { name: "Nova" }
           : await resolveDisplayName(client, userId);
         const toolCalls = isBot ? extractToolCalls((msg as any).blocks) : undefined;
         const toolIO = isBot ? extractToolIO(msg) : undefined;
@@ -200,12 +200,12 @@ export async function fetchConversationContext(
 
       result.thread = threadMessages;
 
-      // Check participation: did Aura reply in this thread?
+      // Check participation: did Nova reply in this thread?
       result.isAuraParticipant = threadMessages.some(
         (m) => m.isBot && m.ts !== threadTs,
       );
 
-      // Check if the parent message (first in the array) is Aura's
+      // Check if the parent message (first in the array) is Nova's
       if (threadMessages.length > 0 && threadMessages[0].isBot) {
         result.isAuraThread = true;
       }
@@ -225,7 +225,7 @@ export async function fetchConversationContext(
       const userId = msg.user || msg.bot_id || "unknown";
       const isBot = msg.user === botUserId;
       const { name: displayName } = isBot
-        ? { name: "Aura" }
+        ? { name: "Nova" }
         : await resolveDisplayName(client, userId);
       const toolCalls = isBot ? extractToolCalls((msg as any).blocks) : undefined;
       const toolIO = isBot ? extractToolIO(msg) : undefined;
@@ -240,7 +240,7 @@ export async function fetchConversationContext(
         ...(toolIO?.length && { toolIO }),
       });
 
-      // Check if Aura posted in the channel within the last hour
+      // Check if Nova posted in the channel within the last hour
       if (isBot && msg.ts && parseFloat(msg.ts) > oneHourAgo) {
         result.auraRecentlyActive = true;
       }

--- a/src/slack/home.ts
+++ b/src/slack/home.ts
@@ -637,7 +637,7 @@ export async function publishHomeTab(
     const blocks: any[] = [
       {
         type: "header",
-        text: { type: "plain_text", text: "Aura Settings" },
+        text: { type: "plain_text", text: "Nova Settings" },
       },
       {
         type: "context",

--- a/src/tools/conversations.ts
+++ b/src/tools/conversations.ts
@@ -50,7 +50,7 @@ export function createConversationSearchTools(context?: ScheduleContext) {
   return {
     search_my_conversations: defineTool({
       description:
-        "Search Aura's stored messages database (every message she has sent and received is saved in PostgreSQL). Use this to recall past conversations, find what was discussed about a topic, or look up what a specific person said. Supports two modes: 'text' (keyword/full-text, default) and 'semantic' (vector similarity — better for conceptual queries). Results are grouped by conversation thread with surrounding context. Prefer this over search_messages for DM threads and conversations Aura has been part of — it searches Aura's own database, not Slack's search index, so has better coverage of her conversations. Use offset for pagination.",
+        "Search Nova's stored messages database (every message it has sent and received is saved in PostgreSQL). Use this to recall past conversations, find what was discussed about a topic, or look up what a specific person said. Supports two modes: 'text' (keyword/full-text, default) and 'semantic' (vector similarity — better for conceptual queries). Results are grouped by conversation thread with surrounding context. Prefer this over search_messages for DM threads and conversations Nova has been part of — it searches Nova's own database, not Slack's search index, so has better coverage of its conversations. Use offset for pagination.",
       inputSchema: z.object({
         query: z
           .string()

--- a/src/tools/cursor-agent.ts
+++ b/src/tools/cursor-agent.ts
@@ -7,7 +7,7 @@ import type { ScheduleContext } from "../db/schema.js";
 import { isAdmin } from "../lib/permissions.js";
 import { logger } from "../lib/logger.js";
 
-const DEFAULT_REPO = process.env.DEFAULT_GITHUB_REPO ?? "AuraHQ-ai/aura";
+const DEFAULT_REPO = process.env.DEFAULT_GITHUB_REPO ?? "wieseljonas/nova";
 
 /**
  * Create Cursor Cloud Agent tools for the AI SDK.
@@ -17,7 +17,7 @@ export function createCursorAgentTools(context?: ScheduleContext) {
   return {
     dispatch_cursor_agent: defineTool({
       description:
-        "Dispatch an async Cursor Cloud Agent to work on a code task in the Aura repo. " +
+        "Dispatch an async Cursor Cloud Agent to work on a code task in the Nova repo. " +
         "Use for complex multi-file changes that would take >5 minutes in the sandbox (refactors, new features, multi-step bug fixes). " +
         "Do NOT use for simple one-line fixes or tasks that run_command handles in <2 minutes. " +
         "The agent runs in the background (3-30 min), creates a branch, makes changes, opens a PR, and results arrive via webhook DM. " +
@@ -50,7 +50,7 @@ export function createCursorAgentTools(context?: ScheduleContext) {
           .string()
           .optional()
           .describe(
-            "GitHub repository in owner/repo format, e.g. 'org/repo'. Defaults to 'AuraHQ-ai/aura'",
+            "GitHub repository in owner/repo format, e.g. 'org/repo'. Defaults to 'wieseljonas/nova'",
           ),
       }),
       execute: async ({ issue_description, branch_prefix, ref, key_files, repository }) => {
@@ -89,12 +89,12 @@ export function createCursorAgentTools(context?: ScheduleContext) {
               ? `\n\nKey files to focus on:\n${key_files.map((f) => `- ${f}`).join("\n")}`
               : "";
 
-          const isAuraRepo = repo === DEFAULT_REPO;
-          const repoDescription = isAuraRepo
-            ? `This is the Aura project (github.com/${repo}) — a Slack AI assistant built with TypeScript, Hono, Vercel serverless, AI SDK v6, and PostgreSQL.`
+          const isNovaRepo = repo === DEFAULT_REPO;
+          const repoDescription = isNovaRepo
+            ? `This is the Nova project (github.com/${repo}) — a Slack AI assistant built with TypeScript, Hono, Vercel serverless, AI SDK v6, and PostgreSQL.`
             : `Repository: github.com/${repo}`;
 
-          const instructions = isAuraRepo
+          const instructions = isNovaRepo
             ? [
                 `- Use \`inputSchema\` (not \`parameters\`) for AI SDK v6 tools`,
                 `- Use .js extensions in imports (ESM with "type": "module")`,

--- a/src/tools/drive.ts
+++ b/src/tools/drive.ts
@@ -24,7 +24,7 @@ function getDriveNoAccessError(
   context?: ScheduleContext,
 ): string {
   if (userName) {
-    return `No Google Drive access for '${userName}'. They may need to authorize Aura via OAuth first.`;
+    return `No Google Drive access for '${userName}'. They may need to authorize Nova via OAuth first.`;
   }
   if (context?.userId) {
     return "You need to connect your Google account first. Ask me to generate an auth link.";

--- a/src/tools/email.ts
+++ b/src/tools/email.ts
@@ -17,7 +17,7 @@ export function createEmailTools(context?: ScheduleContext) {
   return {
     send_email: defineTool({
       description:
-        "Send an email. Defaults to sending from Aura's configured email address. Set user_name to send from another user's account (requires that user's OAuth access, and caller must be that user or an admin). Use for external communication, follow-ups, outreach, and reports. Never send emails without being asked or having a clear reason (job, follow-up, etc.). Body is sent as plain text — keep it professional but conversational, same tone as Slack. DM privacy applies: don't email someone's private Slack DM content to others. Supports optional file attachments (base64-encoded).",
+        "Send an email. Defaults to sending from Nova's configured email address. Set user_name to send from another user's account (requires that user's OAuth access, and caller must be that user or an admin). Use for external communication, follow-ups, outreach, and reports. Never send emails without being asked or having a clear reason (job, follow-up, etc.). Body is sent as plain text — keep it professional but conversational, same tone as Slack. DM privacy applies: don't email someone's private Slack DM content to others. Supports optional file attachments (base64-encoded).",
       inputSchema: z.object({
         to: z.string().describe("Recipient email address"),
         subject: z.string().describe("Email subject line"),
@@ -36,7 +36,7 @@ export function createEmailTools(context?: ScheduleContext) {
           .string()
           .optional()
           .describe(
-            "Send from this user's account instead of Aura. The display name, real name, or username, e.g. 'Joan' or '@joan'. Omit to send from Aura's configured email address.",
+            "Send from this user's account instead of Nova. The display name, real name, or username, e.g. 'Joan' or '@joan'. Omit to send from Nova's configured email address.",
           ),
         attachments: z
           .array(
@@ -91,7 +91,7 @@ export function createEmailTools(context?: ScheduleContext) {
           }, resolvedUserId);
 
           if (!result) {
-            return { ok: false, error: `Failed to send email: no Gmail access for the resolved user. They may need to authorize Aura via OAuth first.` };
+            return { ok: false, error: `Failed to send email: no Gmail access for the resolved user. They may need to authorize Nova via OAuth first.` };
           }
 
           logger.info("send_email tool called", {
@@ -123,7 +123,7 @@ export function createEmailTools(context?: ScheduleContext) {
     }),
 
     reply_to_email: defineTool({
-      description: "Reply to an existing email thread. Defaults to replying from Aura's configured email address. Set user_name to reply from another user's account (requires that user's OAuth access, and caller must be that user or an admin). Requires message_id and thread_id from read_user_emails or read_user_email.",
+      description: "Reply to an existing email thread. Defaults to replying from Nova's configured email address. Set user_name to reply from another user's account (requires that user's OAuth access, and caller must be that user or an admin). Requires message_id and thread_id from read_user_emails or read_user_email.",
       inputSchema: z.object({
         message_id: z
           .string()
@@ -136,7 +136,7 @@ export function createEmailTools(context?: ScheduleContext) {
           .string()
           .optional()
           .describe(
-            "Reply from this user's account instead of Aura. The display name, real name, or username, e.g. 'Joan' or '@joan'. Omit to reply from Aura's configured email address.",
+            "Reply from this user's account instead of Nova. The display name, real name, or username, e.g. 'Joan' or '@joan'. Omit to reply from Nova's configured email address.",
           ),
       }),
       execute: async ({ message_id, thread_id, body, user_name }) => {
@@ -165,7 +165,7 @@ export function createEmailTools(context?: ScheduleContext) {
           const result = await replyToEmail(message_id, thread_id, body, resolvedUserId);
 
           if (!result) {
-            return { ok: false, error: "Failed to reply to email: no Gmail access for the resolved user. They may need to authorize Aura via OAuth first." };
+            return { ok: false, error: "Failed to reply to email: no Gmail access for the resolved user. They may need to authorize Nova via OAuth first." };
           }
 
           logger.info("reply_to_email tool called", {
@@ -404,7 +404,7 @@ export function createEmailTools(context?: ScheduleContext) {
             return {
               ok: false,
               error: user_name
-                ? `No calendar access for '${user_name}'. They may need to authorize Aura via OAuth first.`
+                ? `No calendar access for '${user_name}'. They may need to authorize Nova via OAuth first.`
                 : context?.userId
                   ? "You need to connect your Google account first. Ask me to generate an auth link."
                   : "Calendar is not configured. The OAuth token may need calendar scopes.",
@@ -467,7 +467,7 @@ export function createEmailTools(context?: ScheduleContext) {
             return {
               ok: false,
               error: user_name
-                ? `No calendar access for '${user_name}'. They may need to authorize Aura via OAuth first.`
+                ? `No calendar access for '${user_name}'. They may need to authorize Nova via OAuth first.`
                 : context?.userId
                   ? "You need to connect your Google account first. Ask me to generate an auth link."
                   : "Calendar is not configured. The OAuth token may need calendar scopes.",
@@ -533,7 +533,7 @@ export function createEmailTools(context?: ScheduleContext) {
             return {
               ok: false,
               error: user_name
-                ? `No calendar access for '${user_name}'. They may need to authorize Aura via OAuth first.`
+                ? `No calendar access for '${user_name}'. They may need to authorize Nova via OAuth first.`
                 : context?.userId
                   ? "You need to connect your Google account first. Ask me to generate an auth link."
                   : "Calendar is not configured. The OAuth token may need calendar scopes.",
@@ -576,7 +576,7 @@ export function createEmailTools(context?: ScheduleContext) {
             return {
               ok: false,
               error: user_name
-                ? `No calendar access for '${user_name}'. They may need to authorize Aura via OAuth first.`
+                ? `No calendar access for '${user_name}'. They may need to authorize Nova via OAuth first.`
                 : context?.userId
                   ? "You need to connect your Google account first. Ask me to generate an auth link."
                   : "Calendar is not configured. The OAuth token may need calendar scopes.",
@@ -636,7 +636,7 @@ export function createEmailTools(context?: ScheduleContext) {
             return {
               ok: false,
               error: user_name
-                ? `No calendar access for '${user_name}'. They may need to authorize Aura via OAuth first.`
+                ? `No calendar access for '${user_name}'. They may need to authorize Nova via OAuth first.`
                 : context?.userId
                   ? "You need to connect your Google account first. Ask me to generate an auth link."
                   : "Calendar is not configured. The OAuth token may need calendar scopes.",
@@ -664,7 +664,7 @@ export function createEmailTools(context?: ScheduleContext) {
 
 /**
  * Create tools for managing Gmail as an Executive Assistant.
- * These tools operate on behalf of specific users who have granted Aura OAuth access.
+ * These tools operate on behalf of specific users who have granted Nova OAuth access.
  * Caller identity enforcement: non-admin callers can only access their own email.
  */
 export function createGmailEATools(context?: ScheduleContext) {
@@ -673,7 +673,7 @@ export function createGmailEATools(context?: ScheduleContext) {
   return {
     create_gmail_draft: defineTool({
       description:
-        "Create a draft email in a user's Gmail account. Defaults to the caller's account. The user must have granted Aura OAuth access first. Supports optional file attachments (base64-encoded).",
+        "Create a draft email in a user's Gmail account. Defaults to the caller's account. The user must have granted Nova OAuth access first. Supports optional file attachments (base64-encoded).",
       inputSchema: z.object({
         user_name: z
           .string()
@@ -763,7 +763,7 @@ export function createGmailEATools(context?: ScheduleContext) {
           if (!result) {
             return {
               ok: false,
-              error: `No Gmail access for the resolved user. They need to authorize Aura via the OAuth flow first.`,
+              error: `No Gmail access for the resolved user. They need to authorize Nova via the OAuth flow first.`,
             };
           }
 
@@ -786,7 +786,7 @@ export function createGmailEATools(context?: ScheduleContext) {
 
     list_gmail_drafts: defineTool({
       description:
-        "List draft emails in a user's Gmail account. Defaults to the caller's account. The user must have granted Aura OAuth access.",
+        "List draft emails in a user's Gmail account. Defaults to the caller's account. The user must have granted Nova OAuth access.",
       inputSchema: z.object({
         user_name: z
           .string()
@@ -829,7 +829,7 @@ export function createGmailEATools(context?: ScheduleContext) {
           if (!drafts) {
             return {
               ok: false,
-              error: `No Gmail access for the resolved user. They need to authorize Aura via OAuth first.`,
+              error: `No Gmail access for the resolved user. They need to authorize Nova via OAuth first.`,
             };
           }
 
@@ -851,7 +851,7 @@ export function createGmailEATools(context?: ScheduleContext) {
 
     read_user_emails: defineTool({
       description:
-        "Read recent emails from a user's Gmail inbox. Defaults to the caller's account. The user must have granted Aura OAuth access. Supports pagination via page_token.",
+        "Read recent emails from a user's Gmail inbox. Defaults to the caller's account. The user must have granted Nova OAuth access. Supports pagination via page_token.",
       inputSchema: z.object({
         user_name: z
           .string()
@@ -914,7 +914,7 @@ export function createGmailEATools(context?: ScheduleContext) {
           if (!result) {
             return {
               ok: false,
-              error: `No Gmail access for the resolved user. They need to authorize Aura via OAuth first.`,
+              error: `No Gmail access for the resolved user. They need to authorize Nova via OAuth first.`,
             };
           }
 
@@ -997,7 +997,7 @@ export function createGmailEATools(context?: ScheduleContext) {
 
     delete_gmail_draft: defineTool({
       description:
-        "Delete a draft email from a user's Gmail account. Defaults to the caller's account. The user must have granted Aura OAuth access.",
+        "Delete a draft email from a user's Gmail account. Defaults to the caller's account. The user must have granted Nova OAuth access.",
       inputSchema: z.object({
         user_name: z
           .string()
@@ -1188,7 +1188,7 @@ export function createGmailEATools(context?: ScheduleContext) {
 
     generate_gmail_auth_url: defineTool({
       description:
-        "Generate a Google OAuth consent URL for a user to connect their Gmail account to Aura. DM the resulting URL to the user — they click it, authorize in Google, and their Gmail is connected for reading and drafting.",
+        "Generate a Google OAuth consent URL for a user to connect their Gmail account to Nova. DM the resulting URL to the user — they click it, authorize in Google, and their Gmail is connected for reading and drafting.",
       inputSchema: z.object({
         user_name: z
           .string()

--- a/src/tools/jobs.ts
+++ b/src/tools/jobs.ts
@@ -412,7 +412,7 @@ export function createJobTools(
 
     dispatch_headless: defineTool({
       description:
-        "Dispatch a task for immediate headless execution (no Slack streaming overhead). Creates a job and triggers it NOW — no waiting for the 30-min heartbeat. Use for heavy work: backfills, data processing, multi-step investigations. The task runs as full Aura with all tools. Results are posted to the callback channel/thread when done. Admin-only.",
+        "Dispatch a task for immediate headless execution (no Slack streaming overhead). Creates a job and triggers it NOW — no waiting for the 30-min heartbeat. Use for heavy work: backfills, data processing, multi-step investigations. The task runs as full Nova with all tools. Results are posted to the callback channel/thread when done. Admin-only.",
       inputSchema: z.object({
         task: z
           .string()

--- a/src/tools/people.ts
+++ b/src/tools/people.ts
@@ -63,7 +63,7 @@ interface PersonResult {
     workspace_messages: number;
     aura_dm_messages: number;
     last_activity: string | null;
-    last_aura_dm: string | null;
+    last_nova_dm: string | null;
     profile_created: string | null;
   };
 }
@@ -92,7 +92,7 @@ async function enrichPerson(person: typeof people.$inferSelect): Promise<PersonR
   let workspaceMessages = 0;
   let auraDmMessages = 0;
   let lastActivity: string | null = null;
-  let lastAuraDm: string | null = null;
+  let lastNovaDm: string | null = null;
   let profileCreated: string | null = null;
 
   if (person.slackUserId) {
@@ -113,7 +113,7 @@ async function enrichPerson(person: typeof people.$inferSelect): Promise<PersonR
           lastTs: sql<string>`max(${messages.createdAt})`,
           workspaceMessages: sql<number>`count(*) filter (where ${messages.channelType} != 'dm')`,
           auraDmMessages: sql<number>`count(*) filter (where ${messages.channelType} = 'dm')`,
-          lastAuraDm: sql<string>`max(${messages.createdAt}) filter (where ${messages.channelType} = 'dm')`,
+          lastNovaDm: sql<string>`max(${messages.createdAt}) filter (where ${messages.channelType} = 'dm')`,
         })
         .from(messages)
         .where(eq(messages.userId, profile.slackUserId));
@@ -121,7 +121,7 @@ async function enrichPerson(person: typeof people.$inferSelect): Promise<PersonR
       workspaceMessages = Number(msgStats?.workspaceMessages ?? 0);
       auraDmMessages = Number(msgStats?.auraDmMessages ?? 0);
       lastActivity = msgStats?.lastTs ?? null;
-      lastAuraDm = msgStats?.lastAuraDm ?? null;
+      lastNovaDm = msgStats?.lastNovaDm ?? null;
     }
   }
 
@@ -146,7 +146,7 @@ async function enrichPerson(person: typeof people.$inferSelect): Promise<PersonR
       workspace_messages: workspaceMessages,
       aura_dm_messages: auraDmMessages,
       last_activity: lastActivity,
-      last_aura_dm: lastAuraDm,
+      last_nova_dm: lastNovaDm,
       profile_created: profileCreated,
     },
   };
@@ -191,7 +191,7 @@ export function createPeopleTools(context?: ScheduleContext) {
       description:
         "Look up a person in the people database by name, Slack user ID (e.g. 'U0678NQJ2'), or email address. " +
         "Returns structured profile data including job title, gender, preferred language, birthdate, manager, notes/context, " +
-        "all known addresses (email, phone, slack), and Slack activity stats (workspace_messages, aura_dm_messages, last_activity, last_aura_dm). " +
+        "all known addresses (email, phone, slack), and Slack activity stats (workspace_messages, aura_dm_messages, last_activity, last_nova_dm). " +
         "Use this before update_person to confirm identity. For ambiguous name searches, returns up to 3 fuzzy matches.",
       inputSchema: z.object({
         query: z

--- a/src/tools/resources.ts
+++ b/src/tools/resources.ts
@@ -287,7 +287,7 @@ export function createResourceTools(context?: ScheduleContext) {
           .string()
           .optional()
           .describe(
-            "Optional pre-extracted markdown content. Provide this for binaries or non-HTTP URLs; if omitted, Aura fetches the URL and converts it to markdown.",
+            "Optional pre-extracted markdown content. Provide this for binaries or non-HTTP URLs; if omitted, Nova fetches the URL and converts it to markdown.",
           ),
         use_tavily: z
           .boolean()

--- a/src/tools/sheets.ts
+++ b/src/tools/sheets.ts
@@ -34,7 +34,7 @@ function getSheetsNoAccessError(
   context?: ScheduleContext,
 ): string {
   if (userName) {
-    return `No Google Sheets access for '${userName}'. They may need to authorize Aura via OAuth first.`;
+    return `No Google Sheets access for '${userName}'. They may need to authorize Nova via OAuth first.`;
   }
   if (context?.userId) {
     return "You need to connect your Google account first. Ask me to generate an auth link.";
@@ -66,7 +66,7 @@ async function fetchJson<T>(url: string, token: string): Promise<T> {
     }
     if (status === 403) {
       throw new Error(
-        "No access to this spreadsheet. Make sure it's shared with Aura's Google account.",
+        "No access to this spreadsheet. Make sure it's shared with Nova's Google account.",
       );
     }
     throw new Error(`Google Sheets API error ${status}: ${body.slice(0, 300)}`);

--- a/src/tools/slack.ts
+++ b/src/tools/slack.ts
@@ -544,7 +544,7 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
   const tools: Record<string, any> = {
     list_channels: defineTool({
       description:
-        "List Slack channels that Aura is currently a member of (names, topics, member count). Important: this only shows channels Aura has already joined, NOT all public channels in the workspace. Many public channels exist that aren't listed here. To find or join others, use search_channels to fuzzy-search by name, or join_channel with the exact channel name.",
+        "List Slack channels that Nova is currently a member of (names, topics, member count). Important: this only shows channels Nova has already joined, NOT all public channels in the workspace. Many public channels exist that aren't listed here. To find or join others, use search_channels to fuzzy-search by name, or join_channel with the exact channel name.",
       inputSchema: z.object({
         limit: z
           .number()
@@ -609,7 +609,7 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
 
     get_channel_info: defineTool({
       description:
-        "Get detailed information about a Slack channel by name or ID. Returns the channel name, topic, purpose, privacy status, and member count. Works for any channel — not just ones Aura has joined. Use this to resolve a channel ID (like C0BNVKS77) to its human-readable name — never guess channel names or return raw IDs to users.",
+        "Get detailed information about a Slack channel by name or ID. Returns the channel name, topic, purpose, privacy status, and member count. Works for any channel — not just ones Nova has joined. Use this to resolve a channel ID (like C0BNVKS77) to its human-readable name — never guess channel names or return raw IDs to users.",
       inputSchema: z.object({
         channel: z
           .string()
@@ -741,7 +741,7 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
 
     join_channel: defineTool({
       description:
-        "Join a public Slack channel by name or ID. Aura must join a channel before she can read its history or post messages there. Only works for public channels — for private channels, someone must /invite @Aura. This tool can find and join channels that don't appear in list_channels results, since list_channels only shows channels Aura has already joined. If a channel doesn't appear in list_channels, that does NOT mean it's private or doesn't exist — try join_channel first.",
+        "Join a public Slack channel by name or ID. Nova must join a channel before it can read its history or post messages there. Only works for public channels — for private channels, someone must /invite @Nova. This tool can find and join channels that don't appear in list_channels results, since list_channels only shows channels Nova has already joined. If a channel doesn't appear in list_channels, that does NOT mean it's private or doesn't exist — try join_channel first.",
       inputSchema: z.object({
         channel: z
           .string()
@@ -800,7 +800,7 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
 
     read_channel_history: defineTool({
       description:
-        "Read recent messages from a Slack channel. Includes reactions on each message. Aura must be a member of the channel — use join_channel first if needed. Use this instead of web_search for finding workspace content.",
+        "Read recent messages from a Slack channel. Includes reactions on each message. Nova must be a member of the channel — use join_channel first if needed. Use this instead of web_search for finding workspace content.",
       inputSchema: z.object({
         channel: z
           .string()
@@ -890,7 +890,7 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
 
     read_thread_replies: defineTool({
       description:
-        "Read replies from a specific thread in a channel. Works for regular channel threads and Slack List item comment threads. Use this to check what's been discussed in a thread before posting — especially for bug list item threads, to prevent duplicate comments and reference what's already been said. Aura must be a member of the channel.",
+        "Read replies from a specific thread in a channel. Works for regular channel threads and Slack List item comment threads. Use this to check what's been discussed in a thread before posting — especially for bug list item threads, to prevent duplicate comments and reference what's already been said. Nova must be a member of the channel.",
       inputSchema: z.object({
         channel: z
           .string()
@@ -989,7 +989,7 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
 
     send_channel_message: defineTool({
       description:
-        "Send a message to a Slack channel. Aura must be a member of the channel — use join_channel first if needed. Write as yourself — same personality, same tone. Don't suddenly become formal just because you're posting somewhere new.",
+        "Send a message to a Slack channel. Nova must be a member of the channel — use join_channel first if needed. Write as yourself — same personality, same tone. Don't suddenly become formal just because you're posting somewhere new.",
       inputSchema: z.object({
         channel: z
           .string()
@@ -1228,7 +1228,7 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
 
     search_messages: defineTool({
       description:
-        "Search for messages across the entire Slack workspace using Slack's search index. Supports Slack search syntax: 'in:#channel' to filter by channel, 'from:@user' to filter by sender. For DM threads and conversations Aura has been part of, prefer search_my_conversations instead — it searches Aura's stored database which has better coverage of her own conversations. Requires SLACK_USER_TOKEN.",
+        "Search for messages across the entire Slack workspace using Slack's search index. Supports Slack search syntax: 'in:#channel' to filter by channel, 'from:@user' to filter by sender. For DM threads and conversations Nova has been part of, prefer search_my_conversations instead — it searches Nova's stored database which has better coverage of its own conversations. Requires SLACK_USER_TOKEN.",
       inputSchema: z.object({
         query: z
           .string()
@@ -1583,7 +1583,7 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
 
     list_dm_conversations: defineTool({
       description:
-        "List DM conversations Aura has had. Returns the list of users Aura has open DM channels with. Supports cursor pagination — pass the returned next_cursor in follow-up calls to paginate through ALL DM channels. Admin-only.",
+        "List DM conversations Nova has had. Returns the list of users Nova has open DM channels with. Supports cursor pagination — pass the returned next_cursor in follow-up calls to paginate through ALL DM channels. Admin-only.",
       inputSchema: z.object({
         limit: z
           .number()
@@ -1605,7 +1605,7 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
             return {
               ok: false,
               error:
-                "Only admins can list all DM conversations. Use read_dm_history to check your own DM with Aura.",
+                "Only admins can list all DM conversations. Use read_dm_history to check your own DM with Nova.",
             };
           }
 
@@ -2535,7 +2535,7 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
 
     edit_message: defineTool({
       description:
-        "Edit one of Aura's own messages. Can only edit messages Aura posted — not other people's. Use to fix typos, update a posted summary, or correct information. Works in channels and DMs — pass a DM channel ID (D...) or group DM ID (G...) directly.",
+        "Edit one of Nova's own messages. Can only edit messages Nova posted — not other people's. Use to fix typos, update a posted summary, or correct information. Works in channels and DMs — pass a DM channel ID (D...) or group DM ID (G...) directly.",
       inputSchema: z.object({
         channel: z
           .string()
@@ -2573,7 +2573,7 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
 
     delete_message: defineTool({
       description:
-        "Delete one of Aura's own messages. Can only delete messages Aura posted — not other people's. Use to clean up test posts or mistakes. Works in channels and DMs — pass a DM channel ID (D...) or group DM ID (G...) directly.",
+        "Delete one of Nova's own messages. Can only delete messages Nova posted — not other people's. Use to clean up test posts or mistakes. Works in channels and DMs — pass a DM channel ID (D...) or group DM ID (G...) directly.",
       inputSchema: z.object({
         channel: z
           .string()
@@ -2704,7 +2704,7 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
     }),
 
     remove_reaction: defineTool({
-      description: "Remove an emoji reaction Aura previously added to a message.",
+      description: "Remove an emoji reaction Nova previously added to a message.",
       inputSchema: z.object({
         channel: z
           .string()
@@ -2795,7 +2795,7 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
 
     set_channel_topic: defineTool({
       description:
-        "Set or update a channel's topic text. Aura must be a member of the channel.",
+        "Set or update a channel's topic text. Nova must be a member of the channel.",
       inputSchema: z.object({
         channel: z
           .string()
@@ -2827,7 +2827,7 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
 
     invite_to_channel: defineTool({
       description:
-        "Invite a user to a channel. Aura must be a member of the channel. Use when someone asks to pull someone into a conversation.",
+        "Invite a user to a channel. Nova must be a member of the channel. Use when someone asks to pull someone into a conversation.",
       inputSchema: z.object({
         channel: z
           .string()
@@ -2877,7 +2877,7 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
     }),
 
     leave_channel: defineTool({
-      description: "Leave a channel Aura is currently a member of. Use when you no longer need to monitor a channel.",
+      description: "Leave a channel Nova is currently a member of. Use when you no longer need to monitor a channel.",
       inputSchema: z.object({
         channel: z
           .string()
@@ -2909,7 +2909,7 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
 
     set_my_status: defineTool({
       description:
-        "Set Aura's own Slack status (text + emoji, optional auto-expire). Use during long-running background work to signal what you're doing (e.g. ':mag: Running morning digest'). Always set expiration_minutes so the status auto-clears when done.",
+        "Set Nova's own Slack status (text + emoji, optional auto-expire). Use during long-running background work to signal what you're doing (e.g. ':mag: Running morning digest'). Always set expiration_minutes so the status auto-clears when done.",
       inputSchema: z.object({
         status_text: z
           .string()

--- a/src/users/profiles.ts
+++ b/src/users/profiles.ts
@@ -165,7 +165,7 @@ Analyze the user's message style:
 
 Also extract any new facts you can identify — role, team, interests, personal details, or preferences.
 Only include new facts that are clearly stated or strongly implied. Don't speculate.`,
-      prompt: `User message: ${userMessage}\n\nAura's response: ${assistantResponse}`,
+      prompt: `User message: ${userMessage}\n\nNova's response: ${assistantResponse}`,
     });
 
     if (!object) {


### PR DESCRIPTION
## What this does
Renames all user-facing references from Aura to Nova across 25 files.

### Changed (126 lines each way, pure rename)
- **System prompt**: 'You are Nova -- a team member, not a tool'
- **Tool descriptions**: All Slack, email, calendar, drive, BigQuery tool descriptions
- **Should-respond prompts**: LLM gate prompts for channel monitoring
- **Email signatures**: HTML + text signatures
- **Name detection regex**: `/\bnova[,:]?\s/i` instead of `/\baura[,:]?\s/i`
- **Default repo**: `wieseljonas/nova` for Cursor agent dispatch
- **Speaker labels**: 'Nova' in conversation history formatting
- **README + package.json**: Package name and docs

### Preserved (intentionally NOT changed)
- `AuraHQ-ai/aura` upstream repo references (kept for provenance)
- Code identifiers: `isAuraParticipant`, `auraEmail`, `AURA_*` env vars
- Internal DB defaults (`'aura'` user ID strings)
- `AURA_BOT_USER_ID` and `AURA_WEBSITE_URL` env var names

### Verification
- All 23 TypeScript files parse cleanly (tested with `ts.createSourceFile`)
- No logic changes -- pure string replacements
- Zero net line change (126 additions, 126 deletions)