### PR TITLE
fix: hide Update button for read-only credential grantees

### DIFF
--- a/src/slack/home.ts
+++ b/src/slack/home.ts
@@ -224,12 +224,14 @@ async function buildUserCredentialBlocks(userId: string): Promise<any[]> {
         : `  ·  expires ${expiresAt.toISOString().slice(0, 10)}`;
     }
 
-    const overflowOptions: any[] = [
-      {
+    const canWrite = isOwner || cred.permission === "write" || cred.permission === "admin";
+    const overflowOptions: any[] = [];
+    if (canWrite) {
+      overflowOptions.push({
         text: { type: "plain_text", text: "Update" },
         value: `api_credential_update_${cred.id}`,
-      },
-    ];
+      });
+    }
     if (isOwner) {
       overflowOptions.push(
         {
@@ -251,18 +253,21 @@ async function buildUserCredentialBlocks(userId: string): Promise<any[]> {
       });
     }
 
-    blocks.push({
+    const section: any = {
       type: "section",
       text: {
         type: "mrkdwn",
         text: `*${cred.name}*  ·  _${source}_ (${permLabel})${expiryText}`,
       },
-      accessory: {
+    };
+    if (overflowOptions.length > 0) {
+      section.accessory = {
         type: "overflow",
         action_id: `api_credential_overflow_${cred.id}`,
         options: overflowOptions,
-      },
-    });
+      };
+    }
+    blocks.push(section);
   }
 
   return blocks;


### PR DESCRIPTION
## Joan's bug

The 'Update' option in the App Home credential overflow menu was visible to **all** users who could see a credential, including read-only grantees. When Joan (a read-only grantee) clicked it, the update silently failed because `hasPermission()` correctly denied write access -- but the UI shouldn't have shown the button in the first place.

## Changes (1 file, 13 additions / 8 deletions)

**`src/slack/home.ts`**
- Gate the 'Update' overflow option on `canWrite` (owner, write, or admin permission)
- If a user has zero overflow options (read-only, no grants to view), omit the overflow menu entirely (Slack requires >= 1 option)

## Before / After

| Permission | Before | After |
|---|---|---|
| owner | Update, Share, Delete, View users | Update, Share, Delete, View users |
| admin | Update | Update |
| write | Update | Update |
| read | Update (broken) | No overflow menu |