### PR TITLE
fix: restrict credential creation to admins only

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -431,6 +431,7 @@ app.post("/api/slack/interactions", async (c) => {
 
       // ── User API Credential actions ──────────────────────────────────
       if (action.action_id === "api_credential_add" && payload.trigger_id) {
+        if (!isAdmin(userId)) return;
         const addPromise = openAddCredentialModal(
           slackClient,
           payload.trigger_id,
@@ -728,6 +729,7 @@ function extractCredentialValue(
 }
 
     if (callbackId === "api_credential_add_submit" && userId) {
+      if (!isAdmin(userId)) return;
       const name = payload.view?.state?.values?.cred_name_block?.cred_name?.value;
       const expiryStr = payload.view?.state?.values?.cred_expiry_block?.cred_expiry?.selected_date;
       const authScheme = (payload.view?.state?.values?.cred_auth_scheme_block?.cred_auth_scheme?.selected_option?.value || "bearer") as

--- a/src/slack/home.ts
+++ b/src/slack/home.ts
@@ -155,7 +155,7 @@ async function buildCredentialBlocks(): Promise<any[]> {
 
 // ── User API Credential Blocks ──────────────────────────────────────────────
 
-async function buildUserCredentialBlocks(userId: string): Promise<any[]> {
+async function buildUserCredentialBlocks(userId: string, userIsAdmin: boolean): Promise<any[]> {
   const creds = await listApiCredentials(userId);
 
   const blocks: any[] = [
@@ -173,17 +173,21 @@ async function buildUserCredentialBlocks(userId: string): Promise<any[]> {
         },
       ],
     },
-    {
-      type: "actions",
-      elements: [
-        {
-          type: "button",
-          text: { type: "plain_text", text: "+ Add Credential", emoji: true },
-          action_id: "api_credential_add",
-          style: "primary",
-        },
-      ],
-    },
+    ...(userIsAdmin
+      ? [
+          {
+            type: "actions",
+            elements: [
+              {
+                type: "button",
+                text: { type: "plain_text", text: "+ Add Credential", emoji: true },
+                action_id: "api_credential_add",
+                style: "primary",
+              },
+            ],
+          },
+        ]
+      : []),
   ];
 
   if (creds.length === 0) {
@@ -778,7 +782,7 @@ export async function publishHomeTab(
       );
     }
 
-    const userCredBlocks = await buildUserCredentialBlocks(userId);
+    const userCredBlocks = await buildUserCredentialBlocks(userId, admin);
     blocks.push(...userCredBlocks);
 
     if (admin) {


### PR DESCRIPTION
## What this does
Hides the **+ Add Credential** button from non-admin users in App Home. Backend handlers also gate on `isAdmin(userId)` as a safety net.

### Changes
- `home.ts`: `buildUserCredentialBlocks` now takes `userIsAdmin` param; button conditionally rendered
- `app.ts`: `isAdmin` check on both the modal-open action and the submit handler

### Behavior
- **Admins**: see + Add Credential, can create credentials as before
- **Non-admins**: see the credentials section (with any shared credentials), but no create button. Backend rejects attempts even if the action is somehow triggered.

Closes the credential access control gap reported by Joan.