### PR TITLE
fix: make username optional for basic auth credentials

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -710,9 +710,9 @@ function extractCredentialValue(
       return JSON.stringify({ client_id: clientId, client_secret: clientSecret, token_url: tokenUrl });
     }
   } else if (authScheme === "basic") {
-    const username = values?.cred_username_block?.cred_username?.value;
+    const username = values?.cred_username_block?.cred_username?.value ?? "";
     const password = values?.cred_password_block?.cred_password?.value;
-    if (username && password) {
+    if (password) {
       return JSON.stringify({ username, password });
     }
   } else if (authScheme === "header" || authScheme === "query") {

--- a/src/slack/home.ts
+++ b/src/slack/home.ts
@@ -388,11 +388,12 @@ function buildCredentialValueBlocks(authScheme: AuthScheme): any[] {
       {
         type: "input",
         block_id: "cred_username_block",
+        optional: true,
         label: { type: "plain_text", text: "Username" },
         element: {
           type: "plain_text_input",
           action_id: "cred_username",
-          placeholder: { type: "plain_text", text: "e.g. admin or user@example.com" },
+          placeholder: { type: "plain_text", text: "Optional — leave blank for API-key-only basic auth" },
         },
       },
       {


### PR DESCRIPTION
Some APIs use basic auth with just an API key as the password and no username (e.g. Close CRM, many internal APIs).

**Changes:**
- `home.ts`: Username field marked `optional: true` with updated placeholder text
- `app.ts`: Backend accepts password-only basic auth (username defaults to empty string)

The runtime (`http-request.ts`) already handles this correctly -- `Buffer.from(':password')` produces valid base64 per RFC 7617.