### PR TITLE
debug: show actual error on credential delete failure

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -547,10 +547,11 @@ app.post("/api/slack/interactions", async (c) => {
               await publishHomeTab(slackClient, userId);
             } catch (err) {
               recordError("interactions.api_credential_delete", err, { userId, credId });
+              const errMsg = err instanceof Error ? err.message : String(err);
               await slackClient.chat.postEphemeral({
                 channel: userId,
                 user: userId,
-                text: `:x: Failed to delete credential. Please try again.`,
+                text: `:x: Failed to delete credential: ${errMsg}`,
               }).catch(() => {});
             }
           })();


### PR DESCRIPTION
The catch block was showing a generic 'Failed to delete credential' message. This surfaces the actual error message so we can diagnose what's throwing.