### PR TITLE
fix: allow empty username for basic auth + show credential errors

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -764,6 +764,19 @@ function extractCredentialValue(
           }
         })();
         waitUntil(addPromise);
+      } else if (name && !value) {
+        // Value extraction failed -- return validation error to the modal
+        console.warn(`[credential-add] value extraction failed for scheme=${authScheme}, user=${userId}, name=${name}`);
+        const errorBlock = authScheme === "basic" ? "cred_password_block"
+          : authScheme === "oauth_client" ? "cred_client_id_block"
+          : authScheme === "header" || authScheme === "query" ? "cred_secret_block"
+          : "cred_value_block";
+        return c.json({
+          response_action: "errors",
+          errors: {
+            [errorBlock]: "Required field is missing. Please fill in all required fields.",
+          },
+        });
       }
     }
 

--- a/src/lib/api-credentials.ts
+++ b/src/lib/api-credentials.ts
@@ -146,11 +146,11 @@ export async function storeApiCredential(
   } else if (authScheme === "basic") {
     try {
       const parsed = JSON.parse(plaintext);
-      if (!parsed.username || !parsed.password) {
-        throw new Error("basic value must contain username and password");
+      if (parsed.username == null || !parsed.password) {
+        throw new Error("basic value must contain a password (username is optional)");
       }
     } catch (e: any) {
-      if (e.message.includes("username") || e.message.includes("password")) throw e;
+      if (e.message.includes("password")) throw e;
       throw new Error("basic value must be valid JSON with username and password keys");
     }
   } else if (authScheme === "header" || authScheme === "query") {


### PR DESCRIPTION
## What this fixes

**Bug 1: Empty username rejected for basic auth**
`storeApiCredential()` validated basic auth with `!parsed.username`, which rejects empty string `""`. Empty usernames are valid for API-key-only basic auth. Changed to `parsed.username == null` so only undefined/null is rejected.

**Bug 2: Credential add/update errors swallowed silently**
When `storeApiCredential()` threw (e.g. the bug above), the catch block only called `recordError()` -- no feedback to the user. The modal closed and the credential silently didn't appear. Now DMs the user with the actual error message, matching the pattern from PR #11 (credential delete errors).

## Changes
- `src/lib/api-credentials.ts`: `!parsed.username` -> `parsed.username == null`
- `src/app.ts`: Error DMs for credential add and update handlers

## Testing
- Create a basic auth credential with empty username and a password -> should succeed
- Create a credential that triggers a validation error -> should receive a DM with the error