### PR TITLE
perf: optimize Vercel build -- single global build pass

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
-    "vercel-build": "tsc && tsx src/db/migrate.ts",
     "postinstall": "rm -rf node_modules/e2b/node_modules/chalk 2>/dev/null; true",
     "start": "node dist/index.js",
     "db:generate": "drizzle-kit generate",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,9 @@
     "target": "ES2022",
     "module": "ES2022",
     "moduleResolution": "bundler",
-    "lib": ["ES2022"],
+    "lib": [
+      "ES2022"
+    ],
     "outDir": "dist",
     "rootDir": "src",
     "strict": true,
@@ -11,15 +13,22 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false,
     "incremental": true,
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     },
     "baseUrl": "."
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "dist"]
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,16 +1,27 @@
 {
   "installCommand": "npm install",
   "framework": null,
-  "regions": ["fra1"],
+  "regions": [
+    "fra1"
+  ],
   "functions": {
     "api/**/*.ts": {
       "maxDuration": 800
     }
   },
   "rewrites": [
-    { "source": "/slack/events", "destination": "/api/index" },
-    { "source": "/health", "destination": "/api/index" },
-    { "source": "/(.*)", "destination": "/api/index" }
+    {
+      "source": "/slack/events",
+      "destination": "/api/index"
+    },
+    {
+      "source": "/health",
+      "destination": "/api/index"
+    },
+    {
+      "source": "/(.*)",
+      "destination": "/api/index"
+    }
   ],
   "crons": [
     {
@@ -21,5 +32,6 @@
       "path": "/api/cron/heartbeat",
       "schedule": "*/30 * * * *"
     }
-  ]
+  ],
+  "buildCommand": "tsc & tsx src/db/migrate.ts & wait"
 }


### PR DESCRIPTION
## Changes
1. **Remove `vercel-build` from package.json** -- this script was running per-function (3x after consolidation, 9x before). Removing it stops the repetition.
2. **Add `buildCommand` to vercel.json** -- runs `tsc & tsx src/db/migrate.ts & wait` once globally before function bundling. Parallelizes tsc and migrate since they're independent.
3. **Disable `declaration`, `declarationMap`, `sourceMap`** in tsconfig -- we don't need .d.ts or .map files in production. Reduces tsc I/O.

## Expected impact
Build time: ~1m30s -> ~45-60s

## Timeline
- 3m44s (original)
- 1m30s (after PR #17 consolidation)
- ~45-60s (this PR)