### PR TITLE
fix: basic auth -- make password optional, username required

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -712,8 +712,8 @@ function extractCredentialValue(
     }
   } else if (authScheme === "basic") {
     const username = values?.cred_username_block?.cred_username?.value;
-    const password = values?.cred_password_block?.cred_password?.value;
-    if (username && password) {
+    const password = values?.cred_password_block?.cred_password?.value ?? "";
+    if (username) {
       return JSON.stringify({ username, password });
     }
   } else if (authScheme === "header" || authScheme === "query") {
@@ -756,7 +756,7 @@ function extractCredentialValue(
       } else if (name && !value) {
         // Value extraction failed -- return validation error to the modal
         console.warn(`[credential-add] value extraction failed for scheme=${authScheme}, user=${userId}, name=${name}`);
-        const errorBlock = authScheme === "basic" ? "cred_password_block"
+        const errorBlock = authScheme === "basic" ? "cred_username_block"
           : authScheme === "oauth_client" ? "cred_client_id_block"
           : authScheme === "header" || authScheme === "query" ? "cred_secret_block"
           : "cred_value_block";

--- a/src/lib/api-credentials.ts
+++ b/src/lib/api-credentials.ts
@@ -145,8 +145,8 @@ export async function storeApiCredential(
   } else if (authScheme === "basic") {
     try {
       const parsed = JSON.parse(plaintext);
-      if (parsed.username == null || !parsed.password) {
-        throw new Error("basic value must contain a password (username is optional)");
+      if (!parsed.username) {
+        throw new Error("basic value must contain a username (password is optional)");
       }
     } catch (e: any) {
       if (e.message.includes("password")) throw e;

--- a/src/slack/home.ts
+++ b/src/slack/home.ts
@@ -402,12 +402,12 @@ function buildCredentialValueBlocks(authScheme: AuthScheme): any[] {
       {
         type: "input",
         block_id: "cred_password_block",
-        label: { type: "plain_text", text: "Password" },
+        optional: true,
+        label: { type: "plain_text", text: "Password (optional)" },
         element: {
           type: "plain_text_input",
           action_id: "cred_password",
-          // Note: Slack Block Kit does not support password masking on plain_text_input
-          placeholder: { type: "plain_text", text: "Paste password or API key" },
+          placeholder: { type: "plain_text", text: "Leave empty if API key is the username" },
         },
       },
     ];


### PR DESCRIPTION
Close CRM and many APIs use the API key as the **username** with empty password. We had it backwards.

**Before:** username optional, password required
**After:** username required, password optional

### Changes
- `home.ts`: password field marked `optional: true`
- `app.ts`: `extractCredentialValue` requires username, defaults password to `""`
- `api-credentials.ts`: validation flipped -- username required, password optional
- Error block mapping now points to `cred_username_block` (the required field)
- Runtime (`http-request.ts`) already handles `key:` encoding correctly per RFC 7617