### PR TITLE
Json body double encoding

### DIFF
--- a/src/tools/http-request.ts
+++ b/src/tools/http-request.ts
@@ -208,7 +208,9 @@ export function createHttpRequestTool(context?: ScheduleContext) {
           const response = await fetch(requestUrl, {
             method: input.method,
             headers,
-            body: input.body ? JSON.stringify(input.body) : undefined,
+            body: input.body
+              ? (typeof input.body === "string" ? input.body : JSON.stringify(input.body))
+              : undefined,
             redirect: "manual",
             signal: AbortSignal.timeout(input.timeout_ms),
           });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fix `http_request` tool double-encoding JSON body for POST requests.

The `body` parameter was unconditionally `JSON.stringify`'d, causing double-encoding when the AI SDK provided an already-serialized JSON string. This led to 400 errors for APIs expecting JSON POST bodies. The fix now conditionally stringifies the body only if it's not already a string.

---
<p><a href="https://cursor.com/agents/bc-564c4e17-11b0-4670-b238-526c482e041a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-564c4e17-11b0-4670-b238-526c482e041a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->