### PR TITLE
security: remove get_credential from LLM-facing tools

### DIFF
--- a/src/tools/slack.ts
+++ b/src/tools/slack.ts
@@ -21,7 +21,6 @@ import { createPeopleTools } from "./people.js";
 import { createSubagentTools } from "./subagents.js";
 import { createVoiceTools } from "./voice.js";
 import { createResourceTools } from "./resources.js";
-import { createCredentialTools } from "./credentials.js";
 import { createHttpRequestTool } from "./http-request.js";
 import type { ScheduleContext } from "../db/schema.js";
 import { formatForSlack } from "../lib/format.js";
@@ -3000,9 +2999,6 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
 
     // ── People Data Tools (structured person records) ────────────────
     ...createPeopleTools(context),
-
-    // ── Credential Tools (secure credential retrieval) ──────────────
-    ...createCredentialTools(context),
 
     // ── HTTP Request Tool (governed external API calls) ─────────────
     ...createHttpRequestTool(context),


### PR DESCRIPTION
## Problem
`get_credential` returned raw decrypted API keys directly to the LLM context. The LLM could then paste them into sandbox commands, chat messages, or notes -- exactly what happened with the Exa API key in a DM thread today.

## Fix
Remove `get_credential` from LLM tool registration. Credentials now only flow through `http_request`, which injects auth server-side (the key never touches the LLM).

## What changed
- `slack.ts`: Removed `createCredentialTools(context)` spread and its import
- `credentials.ts`: Kept as-is (not deleted) in case it's needed for internal/server-side use later

## What's NOT affected
- `http_request` tool still works -- it imports `getApiCredentialWithType` directly from `api-credentials.ts`
- All credentialed API calls go through `http_request` with `credential_name` param
- No LLM functionality is lost -- `http_request` already supports bearer, basic, header, query, and oauth_client auth schemes