### PR TITLE
fix: DM user on credential save failure

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -765,6 +765,12 @@ function extractCredentialValue(
             await publishHomeTab(slackClient, userId);
           } catch (err) {
             recordError("interactions.api_credential_add", err, { userId, name });
+            try {
+              await slackClient.chat.postMessage({
+                channel: userId,
+                text: `Failed to save credential "${name}": ${err instanceof Error ? err.message : String(err)}`,
+              });
+            } catch { /* best effort */ }
           }
         })();
         waitUntil(addPromise);


### PR DESCRIPTION
The add-credential modal closes immediately (response_action: clear) before the async storeApiCredential call runs. If it throws (e.g. DB constraint violation), the error was silently swallowed -- user just sees the credential not appear with no feedback.

Now sends a DM with the error message on failure.