### PR TITLE
fix: address Bugbot review comments from AuraHQ-ai/aura#689

### DIFF
--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -243,14 +243,14 @@
             {
                   "idx": 34,
                   "version": "7",
-                  "when": 1773398400000,
+                  "when": 1773312001000,
                   "tag": "0034_credential_auth_scheme",
                   "breakpoints": true
             },
             {
                   "idx": 35,
                   "version": "7",
-                  "when": 1773133312831,
+                  "when": 1773312002000,
                   "tag": "0035_google_service_account_auth_scheme",
                   "breakpoints": true
             }

--- a/src/app.ts
+++ b/src/app.ts
@@ -431,7 +431,7 @@ app.post("/api/slack/interactions", async (c) => {
 
       // ── User API Credential actions ──────────────────────────────────
       if (action.action_id === "api_credential_add" && payload.trigger_id) {
-        if (!isAdmin(userId)) return;
+        if (!isAdmin(userId)) continue;
         const addPromise = openAddCredentialModal(
           slackClient,
           payload.trigger_id,
@@ -743,7 +743,7 @@ function extractCredentialValue(
 }
 
     if (callbackId === "api_credential_add_submit" && userId) {
-      if (!isAdmin(userId)) return;
+      if (!isAdmin(userId)) return c.json({});
       const name = payload.view?.state?.values?.cred_name_block?.cred_name?.value;
       const expiryStr = payload.view?.state?.values?.cred_expiry_block?.cred_expiry?.selected_date;
       const authScheme = (payload.view?.state?.values?.cred_auth_scheme_block?.cred_auth_scheme?.selected_option?.value || "bearer") as

--- a/src/tools/http-request.ts
+++ b/src/tools/http-request.ts
@@ -121,7 +121,7 @@ export function createHttpRequestTool(context?: ScheduleContext) {
                   };
                 }
                 const encoded = Buffer.from(
-                  `${basicParsed.username}:${basicParsed.password}`
+                  `${basicParsed.username}:${basicParsed.password ?? ""}`
                 ).toString("base64");
                 headers["Authorization"] = `Basic ${encoded}`;
                 break;

--- a/vercel.json
+++ b/vercel.json
@@ -33,5 +33,5 @@
       "schedule": "*/30 * * * *"
     }
   ],
-  "buildCommand": "tsc & tsx src/db/migrate.ts & wait"
+  "buildCommand": "tsc & P1=$!; tsx src/db/migrate.ts & P2=$!; wait $P1; E1=$?; wait $P2; E2=$?; [ $E1 -eq 0 ] && [ $E2 -eq 0 ]"
 }


### PR DESCRIPTION
## Summary

Replicates the Bugbot fixes from [AuraHQ-ai/aura#689](https://github.com/AuraHQ-ai/aura/pull/689) into our fork.

## Fixes (4 files, 6 lines changed)

1. **Basic auth password fallback** (`http-request.ts`) -- `?? ""` prevents encoding `undefined` when password is missing
2. **Admin gate in action handler** (`app.ts`) -- `return` -> `continue` so the handler still sends HTTP response to Slack (prevents timeout)
3. **Admin gate in view_submission** (`app.ts`) -- `return` -> `return c.json({})` so Slack gets the empty response needed to close the modal
4. **Parallel build** (`vercel.json`) -- capture both PIDs, wait both unconditionally, check both exit codes. No orphaned processes.
5. **Migration timestamps** (`_journal.json`) -- 0034/0035 timestamps now correctly ordered after 0033