### PR TITLE
sync: upstream AuraHQ-ai/aura (2026-03-10 evening)

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -318,3 +318,31 @@ pre code {
     padding: 0 20px;
   }
 }
+
+/* SlackConversation: flush on mobile -- no border, no radius, bleeds edge to edge */
+@media (max-width: 768px) {
+  .slack-conversation-flush {
+    border: none !important;
+    border-radius: 0 !important;
+    margin-left: -24px !important;
+    margin-right: -24px !important;
+  }
+
+  /* Demo conversation list: tighter gap, title acts as separator */
+  .demo-conversation-list {
+    gap: 0 !important;
+  }
+
+  /* Each conversation item: top border as separator, padding above title */
+  .demo-conversation-list > div {
+    border-top: 1px solid var(--col-border);
+    padding-top: 32px;
+    padding-bottom: 32px;
+  }
+
+  /* First item: no top border (no separator needed at the very top) */
+  .demo-conversation-list > div:first-child {
+    border-top: none;
+    padding-top: 0;
+  }
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -264,18 +264,18 @@ export default function Home() {
         <p style={{ fontSize: "0.875rem", color: "var(--text-muted)", marginBottom: "48px" }}>
           Real questions. Real answers. No prompting required.
         </p>
-        <div style={{ display: "flex", flexDirection: "column", gap: "48px", maxWidth: "720px" }}>
+        <div className="demo-conversation-list" style={{ display: "flex", flexDirection: "column", gap: "48px", maxWidth: "720px" }}>
           <div>
             <p style={{ fontSize: "12px", color: "var(--text-muted)", marginBottom: "12px", fontWeight: 500, letterSpacing: "0.04em", textTransform: "uppercase" }}>Sales performance</p>
-            <SlackConversation messages={SALES_LEADERBOARD} />
+            <SlackConversation messages={SALES_LEADERBOARD} className="slack-conversation-flush" />
           </div>
           <div>
             <p style={{ fontSize: "12px", color: "var(--text-muted)", marginBottom: "12px", fontWeight: 500, letterSpacing: "0.04em", textTransform: "uppercase" }}>Marketing analytics</p>
-            <SlackConversation messages={AD_SPEND} />
+            <SlackConversation messages={AD_SPEND} className="slack-conversation-flush" />
           </div>
           <div>
             <p style={{ fontSize: "12px", color: "var(--text-muted)", marginBottom: "12px", fontWeight: 500, letterSpacing: "0.04em", textTransform: "uppercase" }}>Engineering — build failing</p>
-            <SlackConversation messages={BUILD_FAILING} />
+            <SlackConversation messages={BUILD_FAILING} className="slack-conversation-flush" />
           </div>
         </div>
       </section>

--- a/apps/web/src/components/slack-conversation.tsx
+++ b/apps/web/src/components/slack-conversation.tsx
@@ -45,6 +45,8 @@ export type SlackConversationProps = {
   maxWidth?: string;
   /** Dark or light theme override. Defaults to CSS var cascade (system). */
   theme?: "dark" | "light";
+  /** Extra CSS class(es) applied to the root div */
+  className?: string;
 };
 
 // ── Slack mrkdwn parser ──────────────────────────────────────────────────────
@@ -498,7 +500,7 @@ function SlackMessageRow({
       style={{
         display: "flex",
         gap: "0",
-        padding: sameAuthor ? "1px 20px 1px 20px" : "6px 20px 2px 20px",
+        padding: sameAuthor ? "1px 8px 1px 8px" : "6px 8px 2px 8px",
         position: "relative",
       }}
       onMouseEnter={(e) => {
@@ -600,6 +602,7 @@ export function SlackConversation({
   messages,
   maxWidth = "680px",
   theme,
+  className,
 }: SlackConversationProps) {
   // Detect dark from next-themes: checks class="dark" and data-theme="dark" on <html>
   const [themeDark, setThemeDark] = React.useState(false);
@@ -624,13 +627,14 @@ export function SlackConversation({
 
   return (
     <div
+      className={className}
       style={{
         maxWidth,
         fontFamily:
           'Slack-Lato,"Lato",ui-sans-serif,-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif',
         background: bgColor,
         border: `1px solid ${borderColor}`,
-        borderRadius: "12px",
+        borderRadius: "4px",
         overflow: "hidden",
         padding: "8px 0",
       }}

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -27,8 +27,8 @@ export interface InteractiveAgentOptions {
 }
 
 export interface InteractiveAgentResult {
-  agent: ToolLoopAgent<never, ReturnType<typeof createSlackTools>>;
-  tools: ReturnType<typeof createSlackTools>;
+  agent: ToolLoopAgent<never, Awaited<ReturnType<typeof createSlackTools>>>;
+  tools: Awaited<ReturnType<typeof createSlackTools>>;
   modelId: string;
 }
 
@@ -36,7 +36,7 @@ export async function createInteractiveAgent(
   options: InteractiveAgentOptions,
 ): Promise<InteractiveAgentResult> {
   const { modelId, model } = await getMainModel();
-  const tools = createSlackTools(options.slackClient, options.context);
+  const tools = await createSlackTools(options.slackClient, options.context, modelId);
   const systemMessages = buildCachedSystemMessages(
     options.stablePrefix,
     options.conversationContext,
@@ -72,7 +72,7 @@ export interface HeadlessAgentOptions {
 
 export async function createHeadlessAgent(options: HeadlessAgentOptions) {
   const { modelId, model } = await getMainModel();
-  const tools = createSlackTools(options.slackClient, options.context);
+  const tools = await createSlackTools(options.slackClient, options.context, modelId);
 
   const agent = new ToolLoopAgent({
     model,

--- a/src/tools/slack.ts
+++ b/src/tools/slack.ts
@@ -497,7 +497,7 @@ export async function resolveChannelById(
  * Create Slack tools for the AI SDK.
  * Each tool receives the WebClient via closure.
  */
-export function createSlackTools(client: WebClient, context?: ScheduleContext) {
+export async function createSlackTools(client: WebClient, context?: ScheduleContext, modelId?: string) {
   // Resolve thread coordinates for Slack List items.
   // List channels use the list ID with a C prefix (F088... → C088...).
   // Each root message in the channel has a slack_list.list_record_id field
@@ -3005,52 +3005,71 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
   };
 
   // ── Anthropic Tool Discovery ──────────────────────────────────────
-  // Mark infrequently-used tools as deferred so their schemas aren't
-  // sent upfront. Claude discovers them via toolSearch when needed.
-  // Non-Anthropic providers simply ignore providerOptions.anthropic.
-  const DEFERRED_TOOLS = new Set([
-    // BigQuery / Data
-    "list_datasets", "list_tables", "inspect_table", "execute_query",
-    // Google Sheets
-    "read_google_sheet",
-    // Google Drive
-    "search_drive", "read_drive_file", "list_drive_folder", "list_shared_drives",
-    // Calendar
-    "check_calendar", "create_event", "update_event", "delete_event", "find_available_slot",
-    // Canvas
-    "read_canvas", "create_canvas", "edit_canvas", "delete_canvas", "share_canvas", "list_canvases",
-    // Slack Lists
-    "list_slack_list_items", "get_slack_list_item", "create_slack_list_item", "update_slack_list_item", "delete_slack_list_item",
-    // Email
-    "send_email", "reply_to_email",
-    // Email triage (per-user Gmail)
-    "sync_emails", "email_digest", "update_email_thread",
-    "read_user_emails", "read_user_email",
-    "generate_gmail_auth_url", "create_gmail_draft", "list_gmail_drafts", "delete_gmail_draft",
-    // Dev / Code
-    "run_command", "dispatch_headless", "read_job_trace",
-    "dispatch_cursor_agent", "check_cursor_agent", "followup_cursor_agent",
-    "stop_cursor_agent", "get_cursor_conversation", "list_cursor_agents",
-    // Browser
-    "browse", "download_slack_file",
-    // Voice / Calls
-    "list_voice_agents", "place_call", "send_sms", "send_voice_note",
-    // Directory / Contacts
-    "lookup_workspace_user", "list_workspace_users", "lookup_contact",
-    // Checkpoint
-    "checkpoint_plan",
-    // Resources
-    "ingest_resource", "search_resources", "get_resource", "list_resources",
-    // Subagent
-    "run_subagent",
-    // People
-    "get_person", "update_person",
-  ]);
+  // When running on an Anthropic model, mark infrequently-used tools as
+  // deferred so their schemas aren't sent upfront, and register the
+  // tool search meta-tool so Claude can discover them on demand.
+  // Non-Anthropic providers don't support these features.
+  const isAnthropic = modelId?.startsWith("anthropic/") ?? false;
 
-  const deferOpts = { anthropic: { deferLoading: true } };
-  for (const name of DEFERRED_TOOLS) {
-    if (name in tools) {
-      tools[name] = { ...tools[name], providerOptions: deferOpts };
+  if (isAnthropic) {
+    const { anthropic } = await import("@ai-sdk/anthropic");
+    // TODO: toolSearchBm25_20251119() returns an Anthropic-native tool object that bypasses
+    // defineTool(), so it never gets the `slack` metadata we use for Slack action cards.
+    // Workaround: cast to any and attach the slack property manually so the pipeline
+    // renders a proper card (status + detail) instead of the fallback "Done" label.
+    // Long-term fix: Anthropic should expose a way to attach metadata to built-in tools,
+    // or we should wrap it in defineTool() once the SDK supports that pattern.
+    const _toolSearch = anthropic.tools.toolSearchBm25_20251119();
+    ((_toolSearch as unknown) as Record<string, unknown>).slack = {
+      status: "Searching tools...",
+      detail: (i: { query: string }) => i.query,
+    };
+    tools.toolSearch = _toolSearch;
+
+    const DEFERRED_TOOLS = new Set([
+      // BigQuery / Data
+      "list_datasets", "list_tables", "inspect_table", "execute_query",
+      // Google Sheets
+      "read_google_sheet",
+      // Google Drive
+      "search_drive", "read_drive_file", "list_drive_folder", "list_shared_drives",
+      // Calendar
+      "check_calendar", "create_event", "update_event", "delete_event", "find_available_slot",
+      // Canvas
+      "read_canvas", "create_canvas", "edit_canvas", "delete_canvas", "share_canvas", "list_canvases",
+      // Slack Lists (list + get are eager -- used in every bug triage session)
+      "create_slack_list_item", "update_slack_list_item", "delete_slack_list_item",
+      // Email
+      "send_email", "reply_to_email",
+      // Email triage (per-user Gmail)
+      "sync_emails", "email_digest", "update_email_thread",
+      "read_user_emails", "read_user_email",
+      "generate_gmail_auth_url", "create_gmail_draft", "list_gmail_drafts", "delete_gmail_draft",
+      // Dev / Code (run_command is eager -- used reflexively in most sessions)
+      "dispatch_headless", "read_job_trace",
+      "dispatch_cursor_agent", "check_cursor_agent", "followup_cursor_agent",
+      "stop_cursor_agent", "get_cursor_conversation", "list_cursor_agents",
+      // Browser
+      "browse", "download_slack_file",
+      // Voice / Calls
+      "list_voice_agents", "place_call", "send_sms", "send_voice_note",
+      // Directory / Contacts
+      "lookup_workspace_user", "list_workspace_users", "lookup_contact",
+      // Checkpoint
+      "checkpoint_plan",
+      // Resources
+      "ingest_resource", "search_resources", "get_resource", "list_resources",
+      // Subagent
+      "run_subagent",
+      // People
+      "get_person", "update_person",
+    ]);
+
+    const deferOpts = { anthropic: { deferLoading: true } };
+    for (const name of DEFERRED_TOOLS) {
+      if (name in tools) {
+        tools[name] = { ...tools[name], providerOptions: deferOpts };
+      }
     }
   }
 

--- a/src/tools/subagents.ts
+++ b/src/tools/subagents.ts
@@ -25,6 +25,7 @@ async function buildToolScope(
   scope: string,
   client: WebClient,
   context?: ScheduleContext,
+  modelId?: string,
 ) {
   switch (scope) {
     case "email":
@@ -48,7 +49,7 @@ async function buildToolScope(
       };
     case "slack": {
       const { createSlackTools } = await import("./slack.js");
-      return { ...createSlackTools(client, context) };
+      return { ...(await createSlackTools(client, context, modelId)) };
     }
     case "notes":
       return {
@@ -59,7 +60,7 @@ async function buildToolScope(
     case "all":
     default: {
       const { createSlackTools } = await import("./slack.js");
-      return createSlackTools(client, context);
+      return await createSlackTools(client, context, modelId);
     }
   }
 }
@@ -114,13 +115,12 @@ export function createSubagentTools(
           return { ok: false as const, error: "Admin-only tool" };
         }
 
-        const resolvedModel =
+        const { modelId, model } =
           model_preference === "main"
             ? await getMainModel()
-            : { model: await getFastModel() };
-        const model = resolvedModel.model;
+            : { modelId: undefined, model: await getFastModel() };
 
-        const tools = await buildToolScope(scope, client, context);
+        const tools = await buildToolScope(scope, client, context, modelId);
 
         const safeTools = { ...tools };
         delete (safeTools as Record<string, unknown>).run_subagent;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,13 +16,13 @@
     "declaration": false,
     "declarationMap": false,
     "sourceMap": false,
-    "incremental": true,
     "paths": {
       "@/*": [
         "./src/*"
       ]
     },
-    "baseUrl": "."
+    "baseUrl": ".",
+    "incremental": true
   },
   "include": [
     "src/**/*.ts"

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
   "installCommand": "npm install",
+  "buildCommand": "tsc & P1=$!; tsx src/db/migrate.ts & P2=$!; wait $P1; R1=$?; wait $P2; R2=$?; [ $R1 -eq 0 ] && [ $R2 -eq 0 ]",
   "framework": null,
   "regions": [
     "fra1"


### PR DESCRIPTION
## Upstream sync

Merges 7 commits from `AuraHQ-ai/aura` (`4953158..f966aa0`):

### Commits
- `f966aa0` — **perf: build optimization and API route consolidation** (#691)
- `3416911` — **fix: promote run_command, list/get slack list items to eager tools** (#695)
- `08fc21b` — **fix: attach slack card metadata to toolSearch** (#694)
- `41cd684` — **fix: add Anthropic tool search so deferred tools are discoverable** (#693)
- `645890b` — **fix: flush SlackConversation on mobile** (edge-to-edge, no border)
- `bb77538` — **fix: tighter mobile padding in SlackConversation**
- `4953158` — **perf: run tsc + migrate once via buildCommand**

### Conflict resolution
- `tsconfig.json` — removed duplicate `incremental: true` (was in two places, kept the one at bottom matching upstream)

### Net diff vs origin/main
8 files changed, 117 insertions, 65 deletions.