### PR TITLE
feat: sandbox API proxy -- secure credentialed API access from sandbox

### DIFF
--- a/src/api/sandbox-proxy.ts
+++ b/src/api/sandbox-proxy.ts
@@ -1,0 +1,248 @@
+import { Hono } from "hono";
+import { verifySandboxToken, matchesUrlPattern } from "../lib/sandbox-token.js";
+import { getApiCredentialWithType } from "../lib/api-credentials.js";
+import { logger } from "../lib/logger.js";
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+interface ProxyRequest {
+  method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+  url: string;
+  headers?: Record<string, string>;
+  body?: unknown;
+  credential_name: string;
+  credential_owner: string;
+  timeout_ms?: number;
+}
+
+// ── Private IP check (same as http-request.ts) ──────────────────────────────
+
+function isPrivateIP(ip: string): boolean {
+  return (
+    /^10\./.test(ip) ||
+    /^172\.(1[6-9]|2\d|3[01])\./.test(ip) ||
+    /^192\.168\./.test(ip) ||
+    /^127\./.test(ip) ||
+    /^169\.254\./.test(ip) ||
+    /^0\./.test(ip) ||
+    ip === "::1"
+  );
+}
+
+// ── Route ───────────────────────────────────────────────────────────────────
+
+export const sandboxProxyApp = new Hono();
+
+sandboxProxyApp.post("/api/sandbox-proxy", async (c) => {
+  // ── 1. Extract and verify token ────────────────────────────────────────
+  const authHeader = c.req.header("authorization") || "";
+  const token = authHeader.replace(/^Bearer\s+/i, "").trim();
+
+  if (!token) {
+    return c.json({ ok: false, error: "Missing Authorization header" }, 401);
+  }
+
+  const payload = verifySandboxToken(token);
+  if (!payload) {
+    return c.json({ ok: false, error: "Invalid or expired token" }, 401);
+  }
+
+  // ── 2. Parse request body ──────────────────────────────────────────────
+  let req: ProxyRequest;
+  try {
+    req = await c.req.json<ProxyRequest>();
+  } catch {
+    return c.json({ ok: false, error: "Invalid JSON body" }, 400);
+  }
+
+  if (!req.method || !req.url || !req.credential_name || !req.credential_owner) {
+    return c.json(
+      { ok: false, error: "Missing required fields: method, url, credential_name, credential_owner" },
+      400,
+    );
+  }
+
+  // ── 3. Validate method ─────────────────────────────────────────────────
+  if (!payload.methods.includes(req.method)) {
+    logger.warn("sandbox-proxy: method not allowed", {
+      method: req.method,
+      allowed: payload.methods,
+      executionId: payload.executionId,
+    });
+    return c.json(
+      { ok: false, error: `Method ${req.method} not allowed. Allowed: ${payload.methods.join(", ")}` },
+      403,
+    );
+  }
+
+  // ── 4. Validate credential ─────────────────────────────────────────────
+  if (!payload.credentials.includes(req.credential_name)) {
+    logger.warn("sandbox-proxy: credential not allowed", {
+      credential: req.credential_name,
+      allowed: payload.credentials,
+      executionId: payload.executionId,
+    });
+    return c.json(
+      { ok: false, error: `Credential "${req.credential_name}" not allowed by token scope` },
+      403,
+    );
+  }
+
+  // ── 5. Validate URL pattern ────────────────────────────────────────────
+  if (!matchesUrlPattern(req.url, payload.urlPatterns)) {
+    logger.warn("sandbox-proxy: URL not allowed", {
+      url: req.url,
+      patterns: payload.urlPatterns,
+      executionId: payload.executionId,
+    });
+    return c.json(
+      { ok: false, error: `URL "${req.url}" does not match any allowed pattern` },
+      403,
+    );
+  }
+
+  // ── 6. DNS check (no SSRF to private IPs) ─────────────────────────────
+  try {
+    const { hostname } = new URL(req.url);
+    const dns = await import("node:dns/promises");
+    const { address } = await dns.lookup(hostname);
+    if (isPrivateIP(address)) {
+      return c.json({ ok: false, error: "Requests to private IPs are not allowed" }, 403);
+    }
+  } catch (err: any) {
+    return c.json({ ok: false, error: `DNS lookup failed: ${err.message}` }, 400);
+  }
+
+  // ── 7. Resolve credential ─────────────────────────────────────────────
+  const intent = req.method === "GET" ? "read" : "write";
+  // Use a system-level user ID for the proxy (the bot itself)
+  const botUserId = process.env.AURA_BOT_USER_ID || "system";
+
+  let credResult;
+  try {
+    credResult = await getApiCredentialWithType(
+      req.credential_name,
+      req.credential_owner,
+      botUserId,
+      intent,
+    );
+  } catch (err: any) {
+    logger.error("sandbox-proxy: credential resolution failed", {
+      credential: req.credential_name,
+      error: err.message,
+    });
+    return c.json({ ok: false, error: `Credential error: ${err.message}` }, 500);
+  }
+
+  if (!credResult) {
+    return c.json(
+      { ok: false, error: `Credential "${req.credential_name}" not found or access denied` },
+      403,
+    );
+  }
+
+  // ── 8. Build headers with injected credential ─────────────────────────
+  const headers: Record<string, string> = { ...req.headers };
+  // Strip any auth headers the sandbox tried to pass
+  for (const key of Object.keys(headers)) {
+    if (["authorization", "x-api-key", "x-auth-token"].includes(key.toLowerCase())) {
+      delete headers[key];
+    }
+  }
+
+  switch (credResult.authScheme) {
+    case "bearer":
+    case "oauth_client":
+    case "google_service_account":
+      headers["Authorization"] = `Bearer ${credResult.value}`;
+      break;
+    case "basic": {
+      let basicParsed: { username?: string; password: string };
+      try {
+        basicParsed = JSON.parse(credResult.value);
+      } catch {
+        return c.json({ ok: false, error: "basic credential has invalid JSON value" }, 500);
+      }
+      const encoded = Buffer.from(
+        `${basicParsed.username || ""}:${basicParsed.password}`,
+      ).toString("base64");
+      headers["Authorization"] = `Basic ${encoded}`;
+      break;
+    }
+    case "header": {
+      let headerParsed: { key: string; value: string };
+      try {
+        headerParsed = JSON.parse(credResult.value);
+      } catch {
+        return c.json({ ok: false, error: "header credential has invalid JSON value" }, 500);
+      }
+      headers[headerParsed.key] = headerParsed.value;
+      break;
+    }
+    case "query": {
+      let queryParsed: { key: string; value: string };
+      try {
+        queryParsed = JSON.parse(credResult.value);
+      } catch {
+        return c.json({ ok: false, error: "query credential has invalid JSON value" }, 500);
+      }
+      const separator = req.url.includes("?") ? "&" : "?";
+      req.url = `${req.url}${separator}${encodeURIComponent(queryParsed.key)}=${encodeURIComponent(queryParsed.value)}`;
+      break;
+    }
+  }
+
+  // Set Content-Type for requests with body
+  if (req.body && !Object.keys(headers).some((k) => k.toLowerCase() === "content-type")) {
+    headers["Content-Type"] = "application/json";
+  }
+
+  // ── 9. Make the request ────────────────────────────────────────────────
+  const timeoutMs = Math.min(req.timeout_ms || 30_000, 60_000);
+
+  logger.info("sandbox-proxy: forwarding request", {
+    method: req.method,
+    url: req.url,
+    credential: req.credential_name,
+    executionId: payload.executionId,
+  });
+
+  try {
+    const response = await fetch(req.url, {
+      method: req.method,
+      headers,
+      body: req.body
+        ? typeof req.body === "string"
+          ? req.body
+          : JSON.stringify(req.body)
+        : undefined,
+      redirect: "manual",
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+
+    let responseBody: unknown;
+    const contentType = response.headers.get("content-type") ?? "";
+    if (contentType.includes("application/json")) {
+      responseBody = await response.json().catch(() => null);
+    }
+    if (responseBody === undefined || responseBody === null) {
+      const text = await response.text().catch(() => "");
+      responseBody =
+        text.length > 100_000 ? text.slice(0, 100_000) + "... (truncated)" : text;
+    }
+
+    return c.json({
+      ok: response.ok,
+      status: response.status,
+      headers: Object.fromEntries(response.headers.entries()),
+      body: responseBody,
+    });
+  } catch (error: any) {
+    logger.error("sandbox-proxy: request failed", {
+      error: error.message,
+      url: req.url,
+      executionId: payload.executionId,
+    });
+    return c.json({ ok: false, error: `Request failed: ${error.message}` }, 502);
+  }
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,6 +4,7 @@ import { waitUntil } from "@vercel/functions";
 import { cronApp } from "./cron/consolidate.js";
 import { heartbeatApp } from "./cron/heartbeat.js";
 import { elevenlabsWebhookApp } from "./webhook/elevenlabs.js";
+import { sandboxProxyApp } from "./api/sandbox-proxy.js";
 import { runPipeline } from "./pipeline/index.js";
 import {
   publishHomeTab,
@@ -74,6 +75,7 @@ app.route("/", heartbeatApp);
 
 // Mount ElevenLabs voice webhook routes
 app.route("/api/webhook/elevenlabs", elevenlabsWebhookApp);
+app.route("/", sandboxProxyApp);
 
 // ── Slack Signature Verification ────────────────────────────────────────────
 

--- a/src/lib/sandbox-token.ts
+++ b/src/lib/sandbox-token.ts
@@ -1,0 +1,120 @@
+import crypto from "node:crypto";
+import { logger } from "./logger.js";
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export interface SandboxTokenPayload {
+  /** Unique execution/job ID -- binds token to a single run */
+  executionId: string;
+  /** Which credentials the sandbox can use (by name) */
+  credentials: string[];
+  /** Allowed HTTP methods (e.g. ["GET"] for read-only) */
+  methods: ("GET" | "POST" | "PUT" | "PATCH" | "DELETE")[];
+  /** URL patterns the sandbox can access (glob: * = one segment, ** = any) */
+  urlPatterns: string[];
+  /** Expiry as Unix timestamp (seconds) */
+  exp: number;
+}
+
+// ── Secret ──────────────────────────────────────────────────────────────────
+
+function getSecret(): Buffer {
+  // Reuse CREDENTIALS_KEY (already a 32-byte hex secret) for HMAC signing.
+  // This avoids adding a new env var. The HMAC is a different use (signing
+  // vs encryption) so key reuse here is acceptable -- the domains are
+  // cryptographically separated by the HMAC construction.
+  const hex = process.env.CREDENTIALS_KEY;
+  if (!hex || Buffer.from(hex, "hex").length !== 32) {
+    throw new Error(
+      "CREDENTIALS_KEY must be set (64-char hex) for sandbox token signing",
+    );
+  }
+  return Buffer.from(hex, "hex");
+}
+
+// ── Mint ────────────────────────────────────────────────────────────────────
+
+/**
+ * Create a signed, scoped, ephemeral token for sandbox API access.
+ * The token is a base64url-encoded JSON payload + HMAC-SHA256 signature.
+ */
+export function mintSandboxToken(
+  payload: Omit<SandboxTokenPayload, "exp">,
+  ttlSeconds = 600, // 10 minutes default
+): string {
+  const full: SandboxTokenPayload = {
+    ...payload,
+    exp: Math.floor(Date.now() / 1000) + ttlSeconds,
+  };
+  const json = JSON.stringify(full);
+  const payloadB64 = Buffer.from(json).toString("base64url");
+  const sig = crypto
+    .createHmac("sha256", getSecret())
+    .update(payloadB64)
+    .digest("base64url");
+  return `${payloadB64}.${sig}`;
+}
+
+// ── Verify ──────────────────────────────────────────────────────────────────
+
+/**
+ * Verify and decode a sandbox token. Returns null if invalid or expired.
+ */
+export function verifySandboxToken(
+  token: string,
+): SandboxTokenPayload | null {
+  const parts = token.split(".");
+  if (parts.length !== 2) return null;
+
+  const [payloadB64, sig] = parts;
+  const expectedSig = crypto
+    .createHmac("sha256", getSecret())
+    .update(payloadB64)
+    .digest("base64url");
+
+  if (!crypto.timingSafeEqual(Buffer.from(sig), Buffer.from(expectedSig))) {
+    logger.warn("sandbox-token: signature mismatch");
+    return null;
+  }
+
+  let payload: SandboxTokenPayload;
+  try {
+    payload = JSON.parse(Buffer.from(payloadB64, "base64url").toString());
+  } catch {
+    logger.warn("sandbox-token: invalid JSON payload");
+    return null;
+  }
+
+  if (payload.exp < Math.floor(Date.now() / 1000)) {
+    logger.warn("sandbox-token: expired", { exp: payload.exp });
+    return null;
+  }
+
+  return payload;
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Check if a URL matches any of the allowed patterns.
+ * Supports * (one path segment) and ** (any segments).
+ */
+export function matchesUrlPattern(
+  url: string,
+  patterns: string[],
+): boolean {
+  if (patterns.length === 0) return true; // no restrictions = allow all
+  const stripProtocol = (s: string) => s.replace(/^https?:\/\//, "");
+  const normalizedUrl = stripProtocol(url).replace(/\/$/, "");
+
+  for (const pattern of patterns) {
+    const normalizedPattern = stripProtocol(pattern).replace(/\/$/, "");
+    const regexStr = normalizedPattern
+      .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+      .replace(/\*\*/g, "§§")
+      .replace(/\*/g, "[^/]+")
+      .replace(/§§/g, ".*");
+    if (new RegExp(`^${regexStr}$`).test(normalizedUrl)) return true;
+  }
+  return false;
+}

--- a/src/tools/sandbox-api.ts
+++ b/src/tools/sandbox-api.ts
@@ -1,0 +1,208 @@
+import { z } from "zod";
+import { defineTool } from "../lib/tool.js";
+import { mintSandboxToken } from "../lib/sandbox-token.js";
+import { getOrCreateSandbox, getSandboxEnvs } from "../lib/sandbox.js";
+import { logger } from "../lib/logger.js";
+import type { ScheduleContext } from "../db/schema.js";
+
+/**
+ * Create the sandbox API access tool.
+ * Lets the LLM grant the sandbox scoped, time-limited access to
+ * external APIs via the credential proxy -- without exposing raw
+ * credentials or round-tripping every request through the LLM.
+ */
+export function createSandboxApiTools(context?: ScheduleContext) {
+  return {
+    grant_sandbox_api_access: defineTool({
+      description:
+        "Grant the sandbox scoped access to external APIs via a secure proxy. " +
+        "Mints a short-lived token and injects NOVA_PROXY_URL and NOVA_PROXY_TOKEN " +
+        "as env vars in the sandbox. The sandbox can then make credentialed API calls " +
+        "directly (via curl or Python requests) without going through the LLM for each " +
+        "request. The token is scoped to specific credentials, HTTP methods, and URL " +
+        "patterns. Use this before running sandbox scripts that need external API access. " +
+        "Example sandbox usage after granting: " +
+        "curl -X POST $NOVA_PROXY_URL -H 'Authorization: Bearer $NOVA_PROXY_TOKEN' " +
+        "-H 'Content-Type: application/json' -d '{\"method\":\"GET\",\"url\":\"https://api.close.com/api/v1/lead/\",\"credential_name\":\"close_fr\",\"credential_owner\":\"U066V1AN6\"}'",
+      inputSchema: z.object({
+        credentials: z
+          .array(z.string())
+          .min(1)
+          .describe("Credential names the sandbox can use, e.g. ['close_fr']"),
+        credential_owner: z
+          .string()
+          .describe("Slack user ID of the credential owner"),
+        methods: z
+          .array(z.enum(["GET", "POST", "PUT", "PATCH", "DELETE"]))
+          .default(["GET"])
+          .describe("HTTP methods allowed. Default: GET only (read-only)"),
+        url_patterns: z
+          .array(z.string())
+          .default([])
+          .describe(
+            "URL patterns the sandbox can access. Glob: * = one segment, ** = any. " +
+            "E.g. ['https://api.close.com/**']. Empty = allow all URLs.",
+          ),
+        ttl_seconds: z
+          .number()
+          .min(60)
+          .max(3600)
+          .default(600)
+          .describe("Token lifetime in seconds. Default: 600 (10 min). Max: 3600 (1 hour)."),
+      }),
+      execute: async (input) => {
+        try {
+          // Generate a unique execution ID
+          const executionId = `sbx-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+          const token = mintSandboxToken(
+            {
+              executionId,
+              credentials: input.credentials,
+              methods: input.methods,
+              urlPatterns: input.url_patterns,
+            },
+            input.ttl_seconds,
+          );
+
+          // Determine the proxy URL from the deployment
+          const proxyUrl =
+            process.env.VERCEL_URL
+              ? `https://${process.env.VERCEL_URL}/api/sandbox-proxy`
+              : process.env.NOVA_BASE_URL
+                ? `${process.env.NOVA_BASE_URL}/api/sandbox-proxy`
+                : null;
+
+          if (!proxyUrl) {
+            return {
+              ok: false as const,
+              error:
+                "Cannot determine proxy URL. Set VERCEL_URL or NOVA_BASE_URL env var.",
+            };
+          }
+
+          // Inject into sandbox
+          const sandbox = await getOrCreateSandbox();
+          const envs = await getSandboxEnvs();
+
+          // Write token to a file (avoids env var length issues and process listing exposure)
+          await sandbox.files.write("/home/user/.nova-proxy-token", token);
+          await sandbox.commands.run(
+            "chmod 600 /home/user/.nova-proxy-token",
+            { timeoutMs: 5_000, envs },
+          );
+
+          // Also write a helper script for easy usage
+          const helperScript = `#!/usr/bin/env python3
+"""Nova API Proxy client. Auto-generated -- do not edit."""
+import json, os, sys, urllib.request, urllib.error
+
+PROXY_URL = "${proxyUrl}"
+TOKEN_FILE = "/home/user/.nova-proxy-token"
+
+def _token():
+    with open(TOKEN_FILE) as f:
+        return f.read().strip()
+
+def api_request(method, url, credential_name, credential_owner="${input.credential_owner}", body=None, headers=None, timeout=30):
+    """Make a credentialed API request through the Nova proxy."""
+    payload = {
+        "method": method,
+        "url": url,
+        "credential_name": credential_name,
+        "credential_owner": credential_owner,
+        "timeout_ms": timeout * 1000,
+    }
+    if headers:
+        payload["headers"] = headers
+    if body is not None:
+        payload["body"] = body
+
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        PROXY_URL,
+        data=data,
+        headers={
+            "Authorization": f"Bearer {_token()}",
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout + 5) as resp:
+            return json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        return json.loads(e.read())
+
+def get(url, credential_name, **kw):
+    return api_request("GET", url, credential_name, **kw)
+
+def post(url, credential_name, body=None, **kw):
+    return api_request("POST", url, credential_name, body=body, **kw)
+
+def put(url, credential_name, body=None, **kw):
+    return api_request("PUT", url, credential_name, body=body, **kw)
+
+def delete(url, credential_name, **kw):
+    return api_request("DELETE", url, credential_name, **kw)
+
+if __name__ == "__main__":
+    # CLI usage: python3 nova_api.py GET https://api.close.com/api/v1/lead/ close_fr
+    if len(sys.argv) < 4:
+        print("Usage: python3 nova_api.py METHOD URL CREDENTIAL_NAME [BODY_JSON]")
+        sys.exit(1)
+    method, url, cred = sys.argv[1], sys.argv[2], sys.argv[3]
+    body = json.loads(sys.argv[4]) if len(sys.argv) > 4 else None
+    result = api_request(method, url, cred, body=body)
+    print(json.dumps(result, indent=2))
+`;
+
+          await sandbox.files.write("/home/user/nova_api.py", helperScript);
+
+          // Also set env vars for curl-based usage
+          await sandbox.commands.run(
+            `echo 'export NOVA_PROXY_URL="${proxyUrl}"' >> /home/user/.bashrc && ` +
+            `echo 'export NOVA_PROXY_TOKEN="$(cat /home/user/.nova-proxy-token)"' >> /home/user/.bashrc`,
+            { timeoutMs: 5_000, envs },
+          );
+
+          logger.info("sandbox API access granted", {
+            executionId,
+            credentials: input.credentials,
+            methods: input.methods,
+            urlPatterns: input.url_patterns,
+            ttl: input.ttl_seconds,
+          });
+
+          return {
+            ok: true as const,
+            executionId,
+            proxyUrl,
+            ttlSeconds: input.ttl_seconds,
+            credentials: input.credentials,
+            methods: input.methods,
+            urlPatterns: input.url_patterns,
+            usage: {
+              python: `from nova_api import get, post\nresult = get("https://api.close.com/api/v1/lead/", "close_fr")\nprint(result["body"])`,
+              curl: `curl -X POST $NOVA_PROXY_URL -H "Authorization: Bearer $(cat ~/.nova-proxy-token)" -H "Content-Type: application/json" -d '{"method":"GET","url":"https://api.close.com/api/v1/lead/","credential_name":"close_fr","credential_owner":"${input.credential_owner}"}'`,
+              cli: `python3 nova_api.py GET https://api.close.com/api/v1/lead/ close_fr`,
+            },
+          };
+        } catch (error: any) {
+          logger.error("grant_sandbox_api_access failed", {
+            error: error.message,
+          });
+          return { ok: false as const, error: error.message };
+        }
+      },
+      slack: {
+        status: "Granting sandbox API access...",
+        detail: (input) =>
+          `${input.credentials.join(", ")} [${input.methods.join("/")}]`,
+        output: (result: any) =>
+          result.ok
+            ? `Granted: ${result.credentials?.join(", ")} (${result.ttlSeconds}s TTL)`
+            : result.error,
+      },
+    }),
+  };
+}

--- a/src/tools/slack.ts
+++ b/src/tools/slack.ts
@@ -22,6 +22,7 @@ import { createSubagentTools } from "./subagents.js";
 import { createVoiceTools } from "./voice.js";
 import { createResourceTools } from "./resources.js";
 import { createHttpRequestTool } from "./http-request.js";
+import { createSandboxApiTools } from "./sandbox-api.js";
 import type { ScheduleContext } from "../db/schema.js";
 import { formatForSlack } from "../lib/format.js";
 import { safePostMessage } from "../lib/slack-messaging.js";
@@ -2962,6 +2963,7 @@ export async function createSlackTools(client: WebClient, context?: ScheduleCont
 
     // ── Sandbox Tools ────────────────────────────────────────────────────
     ...createSandboxTools(context),
+    ...createSandboxApiTools(context),
 
     // ── Browser Tools (Browserbase + Playwright) ──────────────────────────
     ...createBrowserTools(context),


### PR DESCRIPTION
## What this does
Adds a credential proxy that lets sandbox code (Python, curl) make credentialed API requests **without exposing raw credentials or round-tripping every request through the LLM**.

### The problem
Sandbox scripts that need to call external APIs (Close CRM, Stripe, etc.) currently must round-trip through the LLM: sandbox runs code → returns to LLM → LLM calls `http_request` → result back to LLM → LLM passes to sandbox. Slow, expensive, fragile.

### The solution
Three new files, ~580 lines total:

| File | What it does |
|------|-------------|
| `src/lib/sandbox-token.ts` | HMAC-SHA256 signed, scoped, ephemeral tokens |
| `src/api/sandbox-proxy.ts` | Hono route that validates tokens and injects credentials |
| `src/tools/sandbox-api.ts` | LLM tool to grant sandbox scoped API access |

### How it works
1. LLM calls `grant_sandbox_api_access` specifying scope (credentials, methods, URL patterns, TTL)
2. Server mints a signed token, injects it into the sandbox
3. Sandbox code calls the proxy directly (`curl`, Python, CLI helper)
4. Proxy validates token → enforces scope → injects real credential → forwards request

### Security model
- **Credentials never leave the server** -- sandbox gets an opaque signed token, not the real key
- **Scoped tokens** -- bound to specific credentials, HTTP methods, and URL patterns
- **Short-lived** -- default 10min, max 1hr, HMAC-signed with CREDENTIALS_KEY
- **SSRF protection** -- DNS check blocks private IP access
- **Auth header stripping** -- sandbox can't override injected credentials
- **Reuses existing infrastructure** -- same credential resolution as `http_request`

### Usage (from sandbox)
```python
from nova_api import get, post
# Read leads (auto-generated helper)
result = get('https://api.close.com/api/v1/lead/', 'close_fr')
# Write (if methods=['POST'] was granted)
result = post('https://api.close.com/api/v1/lead/', 'close_fr', body={...})
```

### What's NOT in this PR
- HITL integration for writes via proxy (can be added -- proxy checks approval table)
- Rate limiting on the proxy endpoint
- Audit log integration (logs to stdout, not action_log table yet)

These are follow-ups. The core proxy is usable as-is.