### PR TITLE
fix: gate write-tier operations (POST/PUT/PATCH) behind HITL approval

### DIFF
--- a/src/lib/tool.ts
+++ b/src/lib/tool.ts
@@ -161,8 +161,8 @@ export function defineTool<TInput, TOutput>(config: {
       });
     }
 
-    // Destructive: write pending log → post approval message → throw
-    if (riskTier === "destructive") {
+    // Gate any data-modifying request (write + destructive) behind approval
+    if (riskTier === "destructive" || riskTier === "write") {
       const [logEntry] = await db
         .insert(actionLog)
         .values({


### PR DESCRIPTION
One-line change: the HITL gate in `tool.ts` now catches both `write` and `destructive` risk tiers.

**Before:** Only `DELETE` (destructive tier) triggered approval. `POST/PUT/PATCH` passed through ungoverned.
**After:** Any data-modifying HTTP method requires human approval. `GET/HEAD/OPTIONS` remain auto-approved.

This is required before testing the Close CRM integration -- without it, a `POST` to create a lead would bypass HITL entirely.