### PR TITLE
fix: rewrite HITL to use SDK-native needsApproval (Codex)

### DIFF
--- a/src/cron/execute-job.ts
+++ b/src/cron/execute-job.ts
@@ -5,7 +5,7 @@ import { jobs, notes, jobExecutions } from "../db/schema.js";
 import { logger } from "../lib/logger.js";
 import { safePostMessage } from "../lib/slack-messaging.js";
 import { createHeadlessAgent } from "../lib/agents.js";
-import { executionContext, PendingApprovalError } from "../lib/tool.js";
+import { executionContext } from "../lib/tool.js";
 
 const botToken = process.env.SLACK_BOT_TOKEN || "";
 const slackClient = new WebClient(botToken);
@@ -261,37 +261,6 @@ export async function executeJob(
 
     return true;
   } catch (error: any) {
-    // Governance: if a tool requires approval, suspend the job
-    if (error instanceof PendingApprovalError) {
-      try {
-        await db
-          .update(jobExecutions)
-          .set({
-            status: "failed",
-            finishedAt: new Date(),
-            error: `Awaiting approval: ${error.actionLogId}`,
-          })
-          .where(eq(jobExecutions.id, executionId));
-      } catch { /* non-critical */ }
-
-      await db
-        .update(jobs)
-        .set({
-          status: "pending",
-          approvalStatus: "awaiting_approval",
-          pendingActionLogId: error.actionLogId,
-          updatedAt: new Date(),
-        })
-        .where(eq(jobs.id, jobId));
-
-      logger.info("executeJob: job suspended awaiting approval", {
-        jobId,
-        jobName: job.name,
-        actionLogId: error.actionLogId,
-      });
-      return true;
-    }
-
     // Update execution trace with failure (protected so it can't break retry logic)
     try {
       await db

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -555,7 +555,7 @@ export const actionLog = pgTable(
     approvedBy: text("approved_by"),
     approvedAt: timestamptz("approved_at"),
     idempotencyKey: text("idempotency_key"),
-    // HITL resumption fields
+    // HITL resumption fields (SDK-native approval pattern)
     conversationState: jsonb("conversation_state").$type<{
       channelId: string;
       threadTs?: string;
@@ -569,8 +569,9 @@ export const actionLog = pgTable(
       teamId?: string;
       timezone?: string;
       modelId?: string;
-      toolCallId?: string;
-      previousMessages?: any[];
+      // SDK-native approval: full message history for resumption
+      messages: any[];
+      approvalId: string;
     }>(),
     approvalMessageTs: text("approval_message_ts"),
     approvalChannelId: text("approval_channel_id"),

--- a/src/lib/hitl-resumption.ts
+++ b/src/lib/hitl-resumption.ts
@@ -4,23 +4,18 @@ import { db } from "../db/client.js";
 import { actionLog } from "../db/schema.js";
 import { logger } from "./logger.js";
 import { logError } from "./error-logger.js";
-import { safePostMessage } from "./slack-messaging.js";
 import { createInteractiveAgent } from "./agents.js";
-import { executionContext } from "./tool.js";
-import { streamText } from "ai";
-import { formatForSlack } from "./format.js";
+import { generateText, stepCountIs } from "ai";
+import { getMainModel } from "./ai.js";
 
 /**
- * Resume a conversation after tool approval.
+ * Resume a conversation after tool approval using SDK-native message continuation.
  * 
- * This is the core HITL (Human-in-the-Loop) resumption logic. When a destructive
- * tool call requires approval, the conversation state is saved. After approval,
- * this function:
- * 
- * 1. Retrieves the saved conversation state
- * 2. Executes the approved tool
- * 3. Resumes the LLM conversation with the tool result injected
- * 4. Posts the continuation to Slack
+ * This implements the SDK-native HITL pattern:
+ * 1. Load saved message history from action_log.conversationState
+ * 2. Append a tool-approval-response message granting approval
+ * 3. Re-invoke the AI SDK with the full message history
+ * 4. The SDK naturally executes the approved tool and continues the conversation
  * 
  * @param args Resumption parameters
  * @returns Success status
@@ -33,8 +28,7 @@ export async function resumeConversationAfterApproval(args: {
   const { actionLogId, approvedBy, slackClient } = args;
 
   try {
-    // P1-2 fix: Verify approver is authorized (admin check happens in handleApprovalReaction,
-    // but we double-check here for defense in depth)
+    // Verify approver is authorized
     const { isAdmin } = await import("../slack/home.js");
     if (!isAdmin(approvedBy)) {
       logger.warn("resumeConversationAfterApproval: unauthorized approver", {
@@ -44,7 +38,7 @@ export async function resumeConversationAfterApproval(args: {
       return { ok: false, error: "Unauthorized: only admins can approve actions" };
     }
 
-    // 1. Retrieve the action log entry with conversation state
+    // Retrieve the action log entry with conversation state
     const rows = await db
       .select()
       .from(actionLog)
@@ -61,250 +55,104 @@ export async function resumeConversationAfterApproval(args: {
     }
 
     const state = entry.conversationState;
-    if (!state) {
-      // Legacy approval without conversation state - can't resume
-      logger.warn("Cannot resume: no conversation state saved", { actionLogId });
+    if (!state || !state.messages || !state.approvalId) {
+      logger.warn("Cannot resume: missing conversation state or message history", { actionLogId });
       return { ok: false, error: "No conversation state available for resumption" };
     }
 
-    logger.info("Resuming conversation after approval", {
+    logger.info("Resuming conversation after approval (SDK-native)", {
       actionLogId,
       toolName: entry.toolName,
       userId: state.userId,
       channelId: state.channelId,
+      messageCount: state.messages.length,
     });
 
-    // 2. Execute the approved tool
-    // We need to re-execute the tool with the stored params.
-    // The tool wrapper will see the approved status and execute normally.
-    
-    // Set up execution context
-    const ctx = {
-      triggeredBy: state.userId,
-      triggerType: "user_message" as const,
-      channelId: state.channelId,
-      threadTs: state.threadTs,
-      conversationState: {
-        userMessage: state.userMessage,
-        stablePrefix: state.stablePrefix,
-        conversationContext: state.conversationContext,
-        dynamicContext: state.dynamicContext,
-        files: state.files,
-        teamId: state.teamId,
-        timezone: state.timezone,
-        modelId: state.modelId,
-        channelType: state.channelType,
-      },
-    };
-
-    let toolResult: any;
-    let toolError: any = null;
-
-    try {
-      // Execute the approved tool via the agent
-      const { agent, tools } = await createInteractiveAgent({
-        slackClient,
-        context: {
-          userId: state.userId,
-          channelId: state.channelId,
-          threadTs: state.threadTs,
-          timezone: state.timezone,
-        },
-        stablePrefix: state.stablePrefix,
-        conversationContext: state.conversationContext,
-        dynamicContext: state.dynamicContext,
-      });
-
-      const tool = tools[entry.toolName];
-      if (!tool) {
-        throw new Error(`Tool ${entry.toolName} not found in agent tools`);
-      }
-
-      // P0-2 fix: Set _approvedActionId to bypass governance on re-execution
-      const executionCtx = {
-        ...ctx,
-        _approvedActionId: actionLogId,
-      };
-
-      // Execute in the proper context so the tool wrapper can log it
-      await executionContext.run(executionCtx, async () => {
-        try {
-          // @ts-ignore - We're calling the tool execute function directly
-          toolResult = await tool.execute(entry.params);
-        } catch (err) {
-          toolError = err;
-        }
-      });
-
-      if (toolError) {
-        throw toolError;
-      }
-
-      // Update action log with result
-      await db
-        .update(actionLog)
-        .set({
-          status: "executed",
-          result: toolResult,
-        })
-        .where(eq(actionLog.id, actionLogId));
-
-      logger.info("Approved tool executed successfully", {
-        actionLogId,
-        toolName: entry.toolName,
-      });
-
-    } catch (err: any) {
-      logger.error("Approved tool execution failed", {
-        actionLogId,
-        toolName: entry.toolName,
-        error: err.message,
-        stack: err.stack,
-      });
-
-      // P1-4 fix: Log detailed error server-side
-      logError({
-        errorName: "ApprovedToolExecutionError",
-        errorMessage: err.message,
-        errorCode: "hitl_approved_tool_failed",
-        userId: state.userId,
-        channelId: state.channelId,
-        context: { actionLogId, toolName: entry.toolName, stack: err.stack },
-      });
-
-      // Update action log with failure
-      await db
-        .update(actionLog)
-        .set({
-          status: "failed",
-          result: { error: err.message },
-        })
-        .where(eq(actionLog.id, actionLogId));
-
-      // P1-4 fix: Send generic error message to user, not raw error
-      await safePostMessage(slackClient, {
-        channel: state.channelId,
-        thread_ts: state.threadTs,
-        text: `The approved action failed to execute. The error has been logged for review.`,
-      });
-
-      return { ok: false, error: "Tool execution failed" };
-    }
-
-    // 3. Resume the LLM conversation with the tool result
-    // Build a synthetic tool call result message to inject into the conversation
-    const toolCallMessage = {
-      role: "assistant" as const,
-      content: [
-        {
-          type: "tool-call" as const,
-          toolCallId: `approved-${actionLogId}`,
-          toolName: entry.toolName,
-          args: entry.params,
-        },
-      ],
-    };
-
-    const toolResultMessage = {
+    // Build the approval response message
+    const approvalResponseMessage = {
       role: "tool" as const,
       content: [
         {
-          type: "tool-result" as const,
-          toolCallId: `approved-${actionLogId}`,
-          toolName: entry.toolName,
-          result: toolResult,
+          type: "tool-approval-response" as const,
+          toolCallId: state.approvalId,
+          approved: true,
         },
       ],
     };
 
-    // Continue the conversation with the tool result injected
-    try {
-      const { agent } = await createInteractiveAgent({
-        slackClient,
-        context: {
-          userId: state.userId,
-          channelId: state.channelId,
-          threadTs: state.threadTs,
-          timezone: state.timezone,
-        },
-        stablePrefix: state.stablePrefix,
-        conversationContext: state.conversationContext,
-        dynamicContext: state.dynamicContext,
-      });
+    // Append approval to message history
+    const resumptionMessages = [
+      ...state.messages,
+      approvalResponseMessage,
+    ];
 
-      // Generate continuation with the tool result injected
-      // We use a synthetic conversation that includes the approved tool call and its result
-      const continuationPrompt = `[Tool call approved and executed]
-Tool: ${entry.toolName}
-Result: ${JSON.stringify(toolResult, null, 2).slice(0, 2000)}
-
-Please continue the conversation acknowledging the tool result.`;
-
-      const result = await agent.generate({
-        prompt: continuationPrompt,
-      });
-
-      const responseText = result.text;
-
-      // Post the continuation to Slack
-      const formattedResponse = formatForSlack(responseText);
-      await safePostMessage(slackClient, {
-        channel: state.channelId,
-        thread_ts: state.threadTs,
-        text: formattedResponse,
-      });
-
-      logger.info("Conversation resumed successfully after approval", {
-        actionLogId,
-        toolName: entry.toolName,
-        responseLength: responseText.length,
-      });
-
-      return { ok: true };
-
-    } catch (err: any) {
-      logger.error("Failed to resume conversation after tool execution", {
-        actionLogId,
-        error: err.message,
-        stack: err.stack,
-      });
-
-      // P1-4 fix: Log detailed error with stack trace
-      logError({
-        errorName: "ConversationResumptionError",
-        errorMessage: err.message,
-        errorCode: "hitl_resumption_failed",
+    // Re-create the agent with the same context
+    const { agent, tools } = await createInteractiveAgent({
+      slackClient,
+      context: {
         userId: state.userId,
         channelId: state.channelId,
-        context: { actionLogId, toolName: entry.toolName, stack: err.stack },
-      });
+        threadTs: state.threadTs,
+        timezone: state.timezone,
+      },
+      stablePrefix: state.stablePrefix,
+      conversationContext: state.conversationContext,
+      dynamicContext: state.dynamicContext,
+    });
 
-      // P1-4 fix: Generic message to user, detailed result but no raw error
-      await safePostMessage(slackClient, {
-        channel: state.channelId,
-        thread_ts: state.threadTs,
-        text: `The approved action completed, but I had trouble generating a follow-up response. You can check the action logs for details.`,
-      });
+    // Resume the conversation by re-submitting messages with approval
+    // The SDK will naturally execute the approved tool and continue
+    const result = await generateText({
+      model: (await getMainModel()).model,
+      messages: resumptionMessages as any,
+      tools,
+      stopWhen: stepCountIs(10),
+    });
 
-      return { ok: false, error: "Conversation resumption failed" };
-    }
+    // Update action log with execution result
+    await db
+      .update(actionLog)
+      .set({
+        status: "executed",
+        result: { text: result.text } as any,
+      })
+      .where(eq(actionLog.id, actionLogId));
 
-  } catch (error: any) {
-    logger.error("Resumption handler error", {
+    // Post the continuation to Slack
+    const { formatForSlack } = await import("./format.js");
+    const { safePostMessage } = await import("./slack-messaging.js");
+    
+    const responseText = result.text || "Tool executed successfully.";
+    const formattedResponse = formatForSlack(responseText);
+    
+    await safePostMessage(slackClient, {
+      channel: state.channelId,
+      thread_ts: state.threadTs,
+      text: formattedResponse,
+    });
+
+    logger.info("Conversation resumed successfully after approval", {
       actionLogId,
-      error: error.message,
-      stack: error.stack,
+      toolName: entry.toolName,
+      responseLength: responseText.length,
     });
 
-    // P1-4 fix: Log detailed error with stack
+    return { ok: true };
+
+  } catch (err: any) {
+    logger.error("Failed to resume conversation after approval", {
+      actionLogId,
+      error: err.message,
+      stack: err.stack,
+    });
+
     logError({
-      errorName: "ResumptionHandlerError",
-      errorMessage: error.message,
-      errorCode: "hitl_resumption_handler_error",
-      context: { actionLogId, stack: error.stack },
+      errorName: "ConversationResumptionError",
+      errorMessage: err.message,
+      errorCode: "hitl_resumption_failed",
+      context: { actionLogId, stack: err.stack },
     });
 
-    // P1-4 fix: Generic error message to caller
     return { ok: false, error: "Failed to resume conversation after approval" };
   }
 }
@@ -339,7 +187,6 @@ export async function handleToolRejection(args: {
 
     const state = entry.conversationState;
     if (!state) {
-      // No conversation state - just acknowledge rejection
       logger.info("Tool rejected (no resumption needed)", {
         actionLogId,
         toolName: entry.toolName,
@@ -348,6 +195,7 @@ export async function handleToolRejection(args: {
     }
 
     // Notify the user that the tool was rejected
+    const { safePostMessage } = await import("./slack-messaging.js");
     await safePostMessage(slackClient, {
       channel: state.channelId,
       thread_ts: state.threadTs,
@@ -369,7 +217,6 @@ export async function handleToolRejection(args: {
       stack: error.stack,
     });
 
-    // P1-4 fix: Log detailed error
     logError({
       errorName: "RejectionHandlerError",
       errorMessage: error.message,
@@ -377,7 +224,6 @@ export async function handleToolRejection(args: {
       context: { actionLogId, stack: error.stack },
     });
 
-    // P1-4 fix: Generic error message
     return { ok: false, error: "Failed to handle tool rejection" };
   }
 }

--- a/src/lib/tool.ts
+++ b/src/lib/tool.ts
@@ -15,39 +15,9 @@ export interface ExecutionContext {
   jobId?: string;
   channelId?: string;
   threadTs?: string;
-  // HITL resumption: if set, this tool execution is pre-approved and should bypass governance (P0-2 fix)
-  _approvedActionId?: string;
-  // P1-3: toolCallId from AI SDK stream (if available)
-  toolCallId?: string;
-  // HITL resumption context - populated by pipeline when approval might be needed
-  conversationState?: {
-    userMessage: string;
-    stablePrefix: string;
-    conversationContext: string;
-    dynamicContext?: string;
-    files?: any[];
-    teamId?: string;
-    timezone?: string;
-    modelId?: string;
-    channelType?: string;
-    previousMessages?: any[];
-    toolCallId?: string;
-  };
 }
 
 export const executionContext = new AsyncLocalStorage<ExecutionContext>();
-
-// HITL: Separate storage for conversation state (populated by pipeline)
-export const conversationStateStorage = new AsyncLocalStorage<ExecutionContext["conversationState"]>();
-
-// ── PendingApprovalError ─────────────────────────────────────────────────────
-
-export class PendingApprovalError extends Error {
-  constructor(public readonly actionLogId: string) {
-    super(`Action pending approval: ${actionLogId}`);
-    this.name = "PendingApprovalError";
-  }
-}
 
 // ── Slack Card Metadata ──────────────────────────────────────────────────────
 // Co-located with tool definitions via defineTool() so that Slack card behavior
@@ -124,21 +94,6 @@ export function defineTool<TInput, TOutput>(config: {
       triggeredBy: "unknown",
       triggerType: "autonomous" as const,
     };
-    
-    // HITL: Merge conversation state from separate storage if available
-    const conversationState = conversationStateStorage.getStore();
-    if (conversationState && !ctx.conversationState) {
-      (ctx as any).conversationState = conversationState;
-    }
-
-    // P0-2 fix: If this execution is pre-approved, bypass governance entirely
-    if (ctx._approvedActionId) {
-      logger.info("Governance: bypassing approval check for pre-approved action", {
-        toolName,
-        approvedActionId: ctx._approvedActionId,
-      });
-      return await originalExecute(input);
-    }
 
     let riskTier: "read" | "write" | "destructive" = "write";
     let policy: ApprovalPolicy | null = null;
@@ -161,68 +116,13 @@ export function defineTool<TInput, TOutput>(config: {
       });
     }
 
-    // Gate any data-modifying request (write + destructive) behind approval
-    if (riskTier === "destructive" || riskTier === "write") {
-      const [logEntry] = await db
-        .insert(actionLog)
-        .values({
-          toolName,
-          params: input as any,
-          triggerType: ctx.triggerType,
-          triggeredBy: ctx.triggeredBy,
-          jobId: ctx.jobId ?? null,
-          credentialName: (input as any)?.credential_name ?? null,
-          riskTier,
-          status: "pending_approval",
-          // Store conversation state for resumption (if available)
-          conversationState: ctx.conversationState ? {
-            channelId: ctx.channelId || "",
-            threadTs: ctx.threadTs,
-            userId: ctx.triggeredBy,
-            channelType: ctx.conversationState.channelType || "dm",
-            userMessage: ctx.conversationState.userMessage,
-            stablePrefix: ctx.conversationState.stablePrefix,
-            conversationContext: ctx.conversationState.conversationContext,
-            dynamicContext: ctx.conversationState.dynamicContext,
-            files: ctx.conversationState.files,
-            teamId: ctx.conversationState.teamId,
-            timezone: ctx.conversationState.timezone,
-            modelId: ctx.conversationState.modelId,
-            // P1-3 fix: Populate previousMessages and toolCallId
-            previousMessages: ctx.conversationState.previousMessages,
-            toolCallId: ctx.toolCallId,
-          } : null,
-        })
-        .returning({ id: actionLog.id });
-
-      const approvalMessageInfo = await requestApproval({
-        actionLogId: logEntry.id,
-        toolName,
-        params: input,
-        riskTier,
-        policy: policy,
-        context: ctx,
-      });
-
-      // Store approval message location for later reference
-      if (approvalMessageInfo) {
-        await db
-          .update(actionLog)
-          .set({
-            approvalMessageTs: approvalMessageInfo.ts,
-            approvalChannelId: approvalMessageInfo.channelId,
-          })
-          .where(eq(actionLog.id, logEntry.id));
-      }
-
-      throw new PendingApprovalError(logEntry.id);
-    }
-
-    // Read / Write: execute, then log result
+    // SDK-native approval: For read-tier operations, execute immediately and log.
+    // For write/destructive, the SDK will call needsApproval first, then execution
+    // happens after approval is granted and messages are re-submitted.
     let logId: string | undefined;
 
     try {
-      // Write the log entry before execution (captures params before credential injection)
+      // Log the action
       try {
         const [logEntry] = await db
           .insert(actionLog)
@@ -275,7 +175,34 @@ export function defineTool<TInput, TOutput>(config: {
     }
   };
 
-  const toolConfig = { ...rest, execute: governedExecute };
+  // SDK-native approval: needsApproval function determines if approval is required
+  const needsApproval = async (input: TInput): Promise<boolean> => {
+    const toolName = toolRef.name || "unknown";
+    
+    let riskTier: "read" | "write" | "destructive" = "write";
+    
+    try {
+      const httpInput = input as Record<string, unknown>;
+      const lookup = await lookupPolicy({
+        toolName,
+        url: toolName === "http_request" ? (httpInput.url as string) : undefined,
+        method: toolName === "http_request" ? (httpInput.method as string) : undefined,
+        credentialName: httpInput.credential_name as string | undefined,
+      });
+      const httpInput2 = input as Record<string, unknown>;
+      riskTier = effectiveRiskTier(lookup, toolName === "http_request" ? (httpInput2.method as string) : undefined);
+    } catch (policyErr) {
+      logger.warn("Governance: policy lookup failed for needsApproval check, defaulting to write tier", {
+        toolName,
+        error: policyErr,
+      });
+    }
+
+    // Write and destructive tiers require approval
+    return riskTier === "write" || riskTier === "destructive";
+  };
+
+  const toolConfig = { ...rest, execute: governedExecute, needsApproval };
   const t = tool<TInput, TOutput>(
     toolConfig as unknown as Tool<TInput, TOutput>,
   );

--- a/src/pipeline/respond.ts
+++ b/src/pipeline/respond.ts
@@ -535,27 +535,7 @@ export async function generateResponse(
   }
 
   try {
-    // ── HITL: Wrap agent stream in conversation state storage ───────────
-    // If a destructive tool is called, the governance layer needs conversation
-    // state to resume execution after approval.
-    const { conversationStateStorage } = await import("../lib/tool.js");
-    const conversationState = {
-      userMessage: options.userMessage,
-      stablePrefix: options.stablePrefix,
-      conversationContext: options.conversationContext,
-      dynamicContext: options.dynamicContext,
-      files: options.files,
-      teamId: options.teamId,
-      timezone: options.context?.timezone,
-      modelId,
-      channelType: options.channelType,
-      // P1-3 fix: Capture previousMessages for HITL resumption
-      previousMessages: streamCallOptions.messages || [],
-    };
-
-    const result = await conversationStateStorage.run(conversationState, async () => {
-      return await agent.stream(streamCallOptions as any);
-    });
+    const result = await agent.stream(streamCallOptions as any);
 
     for await (const chunk of result.fullStream) {
       resetTimer();
@@ -681,6 +661,87 @@ export async function generateResponse(
               }
               await tryStreamAppend({ markdown_text: " " });
             }, 20_000);
+          }
+          break;
+        }
+
+        case "tool-approval-request": {
+          // SDK-native approval: A tool needs approval before execution
+          const approvalToolCallId = (chunk as any).toolCallId;
+          const approvalToolName = (chunk as any).toolName;
+          const approvalArgs = (chunk as any).args;
+
+          logger.info("SDK-native approval request detected in stream", {
+            toolCallId: approvalToolCallId,
+            toolName: approvalToolName,
+            channelId,
+          });
+
+          // Save conversation state for resumption
+          const { db } = await import("../db/client.js");
+          const { actionLog } = await import("../db/schema.js");
+          
+          // Build message history up to this point
+          const currentMessages = streamCallOptions.messages || [
+            { role: "user" as const, content: options.userMessage }
+          ];
+
+          const [logEntry] = await db
+            .insert(actionLog)
+            .values({
+              toolName: approvalToolName,
+              params: approvalArgs as any,
+              triggerType: "user_message",
+              triggeredBy: options.context?.userId || "unknown",
+              credentialName: (approvalArgs as any)?.credential_name ?? null,
+              riskTier: "write",
+              status: "pending_approval",
+              conversationState: {
+                channelId,
+                threadTs,
+                userId: options.context?.userId || "unknown",
+                channelType: options.channelType || "dm",
+                userMessage: options.userMessage,
+                stablePrefix: options.stablePrefix,
+                conversationContext: options.conversationContext,
+                dynamicContext: options.dynamicContext,
+                files: options.files,
+                teamId: options.teamId,
+                timezone: options.context?.timezone,
+                modelId,
+                messages: currentMessages,
+                approvalId: approvalToolCallId,
+              },
+            })
+            .returning({ id: actionLog.id });
+
+          // Post approval buttons to Slack
+          const { requestApproval } = await import("../lib/approval.js");
+          const { eq } = await import("drizzle-orm");
+          const approvalMessageInfo = await requestApproval({
+            actionLogId: logEntry.id,
+            toolName: approvalToolName,
+            params: approvalArgs,
+            riskTier: "write",
+            policy: null,
+            context: {
+              userId: options.context?.userId,
+              channelId,
+              threadTs,
+              triggerType: "user_message",
+            },
+            slackClient,
+          });
+
+          // Store approval message location
+          if (approvalMessageInfo) {
+            await db
+              .update(actionLog)
+              .set({
+                approvalMessageTs: approvalMessageInfo.ts,
+                approvalChannelId: approvalMessageInfo.channelId,
+              })
+              .where(eq(actionLog.id, logEntry.id));
           }
           break;
         }


### PR DESCRIPTION
## What this does
Rewrites the HITL approval system to use the Vercel AI SDK's native `needsApproval` pattern instead of the broken `PendingApprovalError` hack.

### Changes (5 files, +200/-396)
- **tool.ts**: Remove `PendingApprovalError`, `conversationStateStorage`, and governance-bypass fields from `ExecutionContext`. Add `needsApproval` async function to `defineTool()` that checks risk tier via `lookupPolicy`/`effectiveRiskTier` — returns true for write/destructive tiers.
- **respond.ts**: Remove `conversationStateStorage` wrapping. Add `tool-approval-request` case in the stream handler: saves full message history + pipeline context to `action_log.conversationState`, posts Slack approval buttons.
- **hitl-resumption.ts**: Complete rewrite. On approval: loads saved messages from action_log, appends tool-approval-response, calls `generateText` with the SDK handling tool execution naturally. Lazy imports for `safePostMessage`.
- **execute-job.ts**: Remove `PendingApprovalError` import and the entire catch block that suspended jobs on approval errors.
- **schema.ts**: Add `messages?: any[]` and `approvalId?: string` to the `conversationState` type on `action_log`.

### How it works now
1. Model calls tool → SDK checks `needsApproval(input)` → returns `true` for write/destructive
2. SDK emits `tool-approval-request` chunk (no PendingApprovalError thrown!)
3. `respond.ts` catches the chunk, persists messages, posts Slack Approve/Reject buttons
4. On approval: `hitl-resumption.ts` loads messages, appends approval, calls `generateText` → SDK runs the tool
5. On rejection: posts rejection message to user

### Verification
- ✅ TypeScript compiles cleanly (`tsc --noEmit` — zero errors)
- Net deletion: removes 196 lines of fragile code

Generated by Nova via OpenAI Codex CLI + cherry-pick from fix/hitl-native-approval