### PR TITLE
fix: use inputSchema instead of parameters in defineTool

### DIFF
--- a/src/lib/tool.ts
+++ b/src/lib/tool.ts
@@ -145,7 +145,7 @@ export function defineTool<TInput, TOutput>(config: {
 
   const toolConfig: Record<string, unknown> = {
     description: rest.description,
-    parameters: rest.inputSchema,
+    inputSchema: rest.inputSchema,
     execute: loggedExecute,
     // SDK-native approval: check risk tier dynamically
     needsApproval: async (input: TInput) => {


### PR DESCRIPTION
## Root cause

PR #38 refactored `defineTool` to explicitly construct the tool config object. The key was named `parameters` instead of `inputSchema`:

```ts
// BROKEN (PR #38)
const toolConfig = {
    parameters: rest.inputSchema,  // wrong key
    ...
};

// FIXED
const toolConfig = {
    inputSchema: rest.inputSchema,  // correct key
    ...
};
```

The SDK's internal `prepareToolsAndToolChoice` reads `tool2.inputSchema` (not `tool2.parameters`). With the wrong key, every tool got an empty schema (`{properties:{}, additionalProperties:false}`), so the model couldn't call any tools -- all parameter validation failed against the empty schema. This caused `AI_NoOutputGeneratedError` on every single response.

## Fix

One line: `parameters` -> `inputSchema`.

## Impact

**P0** -- this broke all tool calls in production after PR #38 was deployed.