### PR TITLE
fix: use inputSchema instead of parameters in defineTool

### DIFF
--- a/src/lib/tool.ts
+++ b/src/lib/tool.ts
@@ -145,7 +145,7 @@ export function defineTool<TInput, TOutput>(config: {
 
   const toolConfig: Record<string, unknown> = {
     description: rest.description,
-    parameters: rest.inputSchema,
+    inputSchema: rest.inputSchema,
     execute: loggedExecute,
     // SDK-native approval: check risk tier dynamically
     needsApproval: async (input: TInput) => {


### PR DESCRIPTION
## Root cause

The Codex HITL rewrite (`89ca789`) changed `defineTool` from spreading `rest` (which included `inputSchema` under its correct key) to explicitly mapping `inputSchema -> parameters`. But the AI SDK's `tool()` function expects `inputSchema`, not `parameters`.

With the wrong key, every tool got an empty schema (`{properties:{}, additionalProperties:false}`). The model couldn't call any tools -- every response produced `AI_NoOutputGeneratedError`.

## Fix

One-liner: `parameters: rest.inputSchema` -> `inputSchema: rest.inputSchema`

## Why tsc didn't catch it

`tool()` accepts a `Record<string, unknown>`-compatible config. Extra/wrong keys don't trigger type errors. The only way to detect this is at runtime.