### PR TITLE
fix: only gate http_request with needsApproval + fix conversation state save

### DIFF
--- a/src/lib/tool.ts
+++ b/src/lib/tool.ts
@@ -151,8 +151,9 @@ export function defineTool<TInput, TOutput>(config: {
     needsApproval: async (input: TInput) => {
       const toolName = toolRef.name || "unknown";
 
-      // Only http_request needs approval gating -- all other tools pass through
-      if (toolName !== "http_request") {
+      // Only http_request needs approval gating -- all other known tools pass through
+      // If toolRef.name is unset (unknown tool), fail-closed to require approval
+      if (toolName !== "http_request" && toolRef.name) {
         return false;
       }
 

--- a/src/pipeline/respond.ts
+++ b/src/pipeline/respond.ts
@@ -831,7 +831,7 @@ export async function generateResponse(
                   threadTs,
                   userId: ctx.triggeredBy,
                   channelType: options.channelType || "channel",
-                  messages: streamCallOptions.messages || (streamCallOptions.prompt ? [{ role: "user" as const, content: streamCallOptions.prompt }] : []),
+                  messages: streamCallOptions.messages || (streamCallOptions.prompt != null ? [{ role: "user" as const, content: streamCallOptions.prompt }] : []),
                   toolCallId: approvalToolCallId,
                   approvalId,
                   stablePrefix: options.stablePrefix,


### PR DESCRIPTION
## What was broken

**Bug 1: Every tool gated behind approval**
`needsApproval` ran `lookupPolicy()` for every tool. With 0 policies in the table, `effectiveRiskTier()` defaults to `write`, so every tool (read_channel_history, list_channels, etc.) triggered approval buttons. This made me completely non-functional.

**Bug 2: Conversation state saved empty messages**
When the user sends a text-only message (no files), `streamCallOptions` uses `prompt` (string), not `messages` (array). The HITL state save did `messages: streamCallOptions.messages || []`, which always saved `[]`. The resume code then threw 'Conversation state messages corrupted: not an array or empty'.

## Fixes

1. `tool.ts`: `needsApproval` returns `false` immediately for any tool that isn't `http_request`
2. `respond.ts`: When `messages` isn't set, constructs it from `prompt` string

## Scope
Only `http_request` is gated behind approval for now. As we add policies for other tools, we can expand the gate.