### PR TITLE
fix: show tool card as complete (not error) when awaiting HITL approval

### DIFF
--- a/src/pipeline/respond.ts
+++ b/src/pipeline/respond.ts
@@ -785,6 +785,41 @@ export async function generateResponse(
             approvalId,
           });
 
+          // Update the tool card to show "awaiting approval" instead of leaving it as in_progress
+          // (which Slack renders as error when the stream ends without a tool-result)
+          const approvalSlackMeta = getSlackMeta(tools[approvalToolName]);
+          const approvalTitle = approvalSlackMeta?.status ?? approvalToolName;
+          const approvalDetails = approvalSlackMeta?.detail?.(approvalInput);
+          const approvalCardPayload = {
+            chunks: [{
+              type: "task_update",
+              id: approvalToolCallId,
+              title: approvalTitle,
+              status: "complete",
+              ...(approvalDetails && { details: approvalDetails }),
+            }],
+          };
+          currentStreamLength += estimateAppendSize(approvalCardPayload);
+          if (!streamingFailed) {
+            await tryStreamAppend(approvalCardPayload);
+            if (streamingFailed) {
+              fallbackStartIdx = accumulatedText.length;
+            }
+          }
+
+          // Record the tool call as awaiting approval (not an error)
+          const approvalPending = pendingToolInputs.get(approvalToolCallId);
+          toolCallRecords.push({
+            name: approvalToolName,
+            input: approvalPending?.input ?? "{}",
+            output: truncateToBytes(JSON.stringify({ status: "awaiting_approval" }), 1500),
+            is_error: false,
+          });
+          pendingToolInputs.delete(approvalToolCallId);
+
+          if (pendingToolInputs.size === 0 && toolKeepAlive) { clearInterval(toolKeepAlive); toolKeepAlive = null; }
+          if (pendingToolInputs.size === 0 && streamKeepAlive) { clearInterval(streamKeepAlive); streamKeepAlive = null; }
+
           try {
             // Save conversation state for resumption after approval
             const { db } = await import("../db/client.js");


### PR DESCRIPTION
## Problem
When `needsApproval` fires for a tool (e.g. `http_request`), the tool card in Slack shows a red error icon even though nothing failed -- the tool is just waiting for human approval.

**Before:** Red error card ("Making HTTP request...") + approval buttons below
**After:** Green complete card + approval buttons below

## Root cause
The `tool-call` event creates a card with `status: 'in_progress'`. When `tool-approval-request` fires, the stream pauses (no `tool-result` ever comes). Slack renders any `in_progress` card as error when the stream finalizes.

## Fix
In the `tool-approval-request` handler:
1. Send a `task_update` with `status: 'complete'` for the same `toolCallId` -- this transitions the card from spinner to green checkmark
2. Clean up `pendingToolInputs` so stream finalization doesn't get confused by dangling entries
3. Record a proper `toolCallRecord` so metadata is accurate

Slack only supports 3 statuses: `in_progress`, `complete`, `error`. 'Complete' is the closest to 'awaiting approval' -- better than showing an error for something that hasn't failed.