### PR TITLE
feat: improve HITL approval UI (issue #45)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -624,62 +624,14 @@ app.post("/api/slack/interactions", async (c) => {
               reactorUserId: userId,
               slackClient,
             });
-            
-            // Update the approval message UI
-            const gaChanId = payload.channel?.id;
-            const gaTs = payload.message?.ts;
-            if (gaChanId && gaTs) {
-              await slackClient.chat.update({
-                channel: gaChanId,
-                ts: gaTs,
-                text: `✅ Approved by <@${userId}> - executing...`,
-                blocks: [{ 
-                  type: "section" as const, 
-                  text: { 
-                    type: "mrkdwn" as const, 
-                    text: `✅ *Approved* by <@${userId}>\n_Executing tool and resuming conversation..._` 
-                  } 
-                }],
-              });
-            }
 
             // HITL: Resume conversation after approval
             const { resumeConversationAfterApproval } = await import("./lib/hitl-resumption.js");
-            const result = await resumeConversationAfterApproval({
+            await resumeConversationAfterApproval({
               actionLogId,
               approvedBy: userId,
               slackClient,
             });
-
-            if (gaChanId && gaTs) {
-              if (result.ok) {
-                await slackClient.chat.update({
-                  channel: gaChanId,
-                  ts: gaTs,
-                  text: `✅ Approved by <@${userId}> - completed`,
-                  blocks: [{ 
-                    type: "section" as const, 
-                    text: { 
-                      type: "mrkdwn" as const, 
-                      text: `✅ *Approved* by <@${userId}>\n✓ Tool executed and conversation resumed` 
-                    } 
-                  }],
-                });
-              } else {
-                await slackClient.chat.update({
-                  channel: gaChanId,
-                  ts: gaTs,
-                  text: `✅ Approved by <@${userId}> - execution failed`,
-                  blocks: [{ 
-                    type: "section" as const, 
-                    text: { 
-                      type: "mrkdwn" as const, 
-                      text: `✅ *Approved* by <@${userId}>\n⚠️ Execution failed: ${result.error || "Unknown error"}` 
-                    } 
-                  }],
-                });
-              }
-            }
           } catch (err) {
             recordError("interactions.governance_approve", err, { userId, actionLogId });
             logger.error("Approval button handler failed", { userId, actionLogId, error: err });
@@ -699,24 +651,6 @@ app.post("/api/slack/interactions", async (c) => {
               reactorUserId: userId,
               slackClient,
             });
-
-            // Update the approval message UI
-            const grChanId = payload.channel?.id;
-            const grTs = payload.message?.ts;
-            if (grChanId && grTs) {
-              await slackClient.chat.update({
-                channel: grChanId,
-                ts: grTs,
-                text: `❌ Rejected by <@${userId}>`,
-                blocks: [{ 
-                  type: "section" as const, 
-                  text: { 
-                    type: "mrkdwn" as const, 
-                    text: `❌ *Rejected* by <@${userId}>\n_Tool will not be executed_` 
-                  } 
-                }],
-              });
-            }
 
             // HITL: Handle rejection
             const { handleToolRejection } = await import("./lib/hitl-resumption.js");

--- a/src/lib/approval.ts
+++ b/src/lib/approval.ts
@@ -139,6 +139,51 @@ export function effectiveRiskTier(
   return "write";
 }
 
+function truncateValue(v: string, max = 200): string {
+  return v.length <= max ? v : `${v.slice(0, max)}...`;
+}
+
+function renderScalar(v: unknown): string {
+  if (v == null) return "null";
+  if (typeof v === "string") return v;
+  if (typeof v === "number" || typeof v === "boolean") return String(v);
+  return truncateValue(JSON.stringify(v), 160);
+}
+
+function summarizeHttpRequest(params: Record<string, unknown>): string {
+  const method = String(params.method ?? "GET").toUpperCase();
+  const url = String(params.url ?? "(missing URL)");
+  const bodyRaw = params.body;
+  const body =
+    typeof bodyRaw === "string"
+      ? bodyRaw
+      : bodyRaw != null
+        ? JSON.stringify(bodyRaw)
+        : "";
+  const bodyLine = body
+    ? `\n*Body (first 200 chars):*\n\`\`\`${truncateValue(body, 200)}\`\`\``
+    : "";
+  return `*Method:* \`${method}\`\n*URL:* ${url}${bodyLine}`;
+}
+
+function summarizeToolParams(toolName: string, params: unknown): string {
+  if (toolName === "http_request" && params && typeof params === "object") {
+    return summarizeHttpRequest(params as Record<string, unknown>);
+  }
+
+  if (!params || typeof params !== "object" || Array.isArray(params)) {
+    return `*Arguments:* \`${renderScalar(params)}\``;
+  }
+
+  const entries = Object.entries(params as Record<string, unknown>).slice(0, 12);
+  if (entries.length === 0) return "*Arguments:* _(none)_";
+
+  const lines = entries.map(([k, v]) => `- *${k}:* \`${truncateValue(renderScalar(v), 180)}\``);
+  const hasMore = Object.keys(params as Record<string, unknown>).length > entries.length;
+  if (hasMore) lines.push("- _...additional fields omitted_");
+  return lines.join("\n");
+}
+
 // ── Request Approval (post Slack message + write action_log row) ────────────
 
 export async function requestApproval(args: {
@@ -171,12 +216,6 @@ export async function requestApproval(args: {
       ? approvers.map((id) => `<@${id}>`).join(", ")
       : "admins";
 
-  const paramsSummary = JSON.stringify(logEntry.params, null, 2);
-  const truncatedParams =
-    paramsSummary.length > 2800
-      ? paramsSummary.slice(0, 2800) + "\n... (truncated)"
-      : paramsSummary;
-
   const blocks = [
     {
       type: "header" as const,
@@ -197,7 +236,7 @@ export async function requestApproval(args: {
       type: "section" as const,
       text: {
         type: "mrkdwn" as const,
-        text: `*Parameters:*\n\`\`\`${truncatedParams}\`\`\``,
+        text: `*Request details:*\n${summarizeToolParams(toolName, logEntry.params ?? params)}`,
       },
     },
     {
@@ -224,7 +263,7 @@ export async function requestApproval(args: {
       elements: [
         {
           type: "mrkdwn" as const,
-          text: `${approverMentions} • \`action_log_id: ${actionLogId}\``,
+          text: `${approverMentions} • Expires in 10 minutes • \`action_log_id: ${actionLogId}\``,
         },
       ],
     },

--- a/src/lib/hitl-resumption.ts
+++ b/src/lib/hitl-resumption.ts
@@ -8,6 +8,37 @@ import { logError } from "./error-logger.js";
 import { executionContext } from "./tool.js";
 import { isAdmin } from "./permissions.js";
 
+function truncateSummary(text: string, max = 500): string {
+  return text.length <= max ? text : `${text.slice(0, max)}...`;
+}
+
+async function updateApprovalMessage(args: {
+  slackClient: WebClient;
+  channelId?: string | null;
+  messageTs?: string | null;
+  text: string;
+  blocks: Array<Record<string, unknown>>;
+}): Promise<boolean> {
+  const { slackClient, channelId, messageTs, text, blocks } = args;
+  if (!channelId || !messageTs) return false;
+  try {
+    await slackClient.chat.update({
+      channel: channelId,
+      ts: messageTs,
+      text,
+      blocks: blocks as any,
+    });
+    return true;
+  } catch (err) {
+    logger.warn("HITL: failed to update approval message", {
+      channelId,
+      messageTs,
+      error: err,
+    });
+    return false;
+  }
+}
+
 /**
  * Resume a conversation after tool approval using SDK-native message replay.
  *
@@ -19,7 +50,7 @@ import { isAdmin } from "./permissions.js";
  * 2. Append a tool-approval-response message (approved: true)
  * 3. Re-invoke generateText with the full message history + all tools
  * 4. The SDK executes the tool naturally and continues the conversation
- * 5. Update action_log status and post the result to Slack
+ * 5. Update action_log status and update the approval card with result summary
  */
 export async function resumeConversationAfterApproval(args: {
   actionLogId: string;
@@ -198,16 +229,47 @@ export async function resumeConversationAfterApproval(args: {
         .where(eq(actionLog.id, actionLogId));
     } catch { /* non-critical */ }
 
-    // 5. Post the result to Slack
+    // 5. Update the original approval message with a result summary
     const { formatForSlack } = await import("./format.js");
-    const { safePostMessage } = await import("./slack-messaging.js");
-
     const responseText = result.text || "Tool executed successfully.";
-    await safePostMessage(slackClient, {
-      channel: state.channelId,
-      thread_ts: state.threadTs,
-      text: formatForSlack(responseText),
+    const formattedSummary = truncateSummary(formatForSlack(responseText), 700);
+    const updated = await updateApprovalMessage({
+      slackClient,
+      channelId: entry.approvalChannelId,
+      messageTs: entry.approvalMessageTs,
+      text: `Approved by <@${approvedBy}>`,
+      blocks: [
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: `*Approved by <@${approvedBy}>*`,
+          },
+        },
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: `*Result summary:*\n${formattedSummary || "_No text response_"}`,
+          },
+        },
+        {
+          type: "context",
+          elements: [
+            { type: "mrkdwn", text: `\`action_log_id: ${actionLogId}\`` },
+          ],
+        },
+      ],
     });
+
+    if (!updated) {
+      const { safePostMessage } = await import("./slack-messaging.js");
+      await safePostMessage(slackClient, {
+        channel: state.channelId,
+        thread_ts: state.threadTs,
+        text: formatForSlack(responseText),
+      });
+    }
 
     logger.info("HITL resumption: completed successfully", {
       actionLogId,
@@ -234,6 +296,48 @@ export async function resumeConversationAfterApproval(args: {
         .where(eq(actionLog.id, actionLogId));
     } catch { /* non-critical */ }
 
+    try {
+      const rows = await db
+        .select({
+          approvalChannelId: actionLog.approvalChannelId,
+          approvalMessageTs: actionLog.approvalMessageTs,
+        })
+        .from(actionLog)
+        .where(eq(actionLog.id, actionLogId))
+        .limit(1);
+      const uiEntry = rows[0];
+      if (uiEntry) {
+        await updateApprovalMessage({
+          slackClient,
+          channelId: uiEntry.approvalChannelId,
+          messageTs: uiEntry.approvalMessageTs,
+          text: `Approved by <@${approvedBy}> - execution failed`,
+          blocks: [
+            {
+              type: "section",
+              text: {
+                type: "mrkdwn",
+                text: `*Approved by <@${approvedBy}>*`,
+              },
+            },
+            {
+              type: "section",
+              text: {
+                type: "mrkdwn",
+                text: `*Execution failed:* ${truncateSummary(err.message || "Unknown error", 350)}`,
+              },
+            },
+            {
+              type: "context",
+              elements: [
+                { type: "mrkdwn", text: `\`action_log_id: ${actionLogId}\`` },
+              ],
+            },
+          ],
+        });
+      }
+    } catch { /* non-critical */ }
+
     logError({
       errorName: "HitlResumptionError",
       errorMessage: err.message,
@@ -248,7 +352,7 @@ export async function resumeConversationAfterApproval(args: {
 /**
  * Handle rejection of a tool call.
  *
- * When a destructive tool is rejected, notify the user in the thread.
+ * When a destructive tool is rejected, update the original approval card.
  */
 export async function handleToolRejection(args: {
   actionLogId: string;
@@ -269,41 +373,59 @@ export async function handleToolRejection(args: {
       return { ok: false, error: "Action log entry not found" };
     }
 
-    // Update status to rejected only if still pending_approval (atomic CAS)
-    const updated = await db
-      .update(actionLog)
-      .set({ status: "rejected" })
-      .where(
-        and(
-          eq(actionLog.id, actionLogId),
-          eq(actionLog.status, "pending_approval"),
-        ),
-      )
-      .returning({ id: actionLog.id });
-
-    if (updated.length === 0) {
-      logger.warn("Tool rejection skipped: action already resolved", {
+    if (entry.status === "pending_approval") {
+      const updated = await db
+        .update(actionLog)
+        .set({ status: "rejected" })
+        .where(
+          and(
+            eq(actionLog.id, actionLogId),
+            eq(actionLog.status, "pending_approval"),
+          ),
+        )
+        .returning({ id: actionLog.id });
+      if (updated.length === 0) {
+        logger.warn("Tool rejection skipped: action already resolved", {
+          actionLogId,
+          currentStatus: entry.status,
+        });
+        return { ok: false, error: "Action already resolved" };
+      }
+    } else if (entry.status !== "rejected") {
+      logger.warn("Tool rejection skipped: unexpected status", {
         actionLogId,
         currentStatus: entry.status,
       });
-      return { ok: false, error: "Action already resolved" };
+      return { ok: false, error: `Unexpected status ${entry.status}` };
     }
 
-    const state = entry.conversationState;
-    if (!state) {
-      logger.info("Tool rejected (no resumption needed)", {
-        actionLogId,
-        toolName: entry.toolName,
-      });
-      return { ok: true };
-    }
-
-    // Notify the user that the tool was rejected
-    const { safePostMessage } = await import("./slack-messaging.js");
-    await safePostMessage(slackClient, {
-      channel: state.channelId,
-      thread_ts: state.threadTs,
-      text: `The requested action (\`${entry.toolName}\`) was rejected by <@${rejectedBy}>. I won't proceed with that operation.`,
+    await updateApprovalMessage({
+      slackClient,
+      channelId: entry.approvalChannelId,
+      messageTs: entry.approvalMessageTs,
+      text: `Rejected by <@${rejectedBy}>`,
+      blocks: [
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: `*Rejected by <@${rejectedBy}>*`,
+          },
+        },
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: `Action \`${entry.toolName}\` will not be executed.`,
+          },
+        },
+        {
+          type: "context",
+          elements: [
+            { type: "mrkdwn", text: `\`action_log_id: ${actionLogId}\`` },
+          ],
+        },
+      ],
     });
 
     logger.info("Tool rejection handled", {

--- a/src/lib/tool.ts
+++ b/src/lib/tool.ts
@@ -27,6 +27,8 @@ export const executionContext = new AsyncLocalStorage<ExecutionContext>();
 export interface SlackToolMetadata<TInput = any, TOutput = any> {
   /** Spinner label shown while tool is running, e.g. "Searching the web..." */
   status: string;
+  /** Optional title used when a tool is waiting on human approval */
+  approvalStatus?: string | ((input: TInput) => string | undefined);
   /** Extract a short detail from input args for the in-progress card */
   detail?: (input: TInput) => string | undefined;
   /** Extract a short summary from result for the completed card */
@@ -45,6 +47,17 @@ export interface SlackToolMetadata<TInput = any, TOutput = any> {
 export function getSlackMeta(t: unknown): SlackToolMetadata | undefined {
   if (t && typeof t === "object" && "slack" in t) {
     return (t as { slack: SlackToolMetadata }).slack;
+  }
+  return undefined;
+}
+
+/**
+ * Retrieve the user-facing description from a tool definition, if present.
+ */
+export function getToolDescription(t: unknown): string | undefined {
+  if (t && typeof t === "object" && "description" in t) {
+    const description = (t as { description?: unknown }).description;
+    return typeof description === "string" ? description : undefined;
   }
   return undefined;
 }

--- a/src/pipeline/respond.ts
+++ b/src/pipeline/respond.ts
@@ -6,7 +6,7 @@ import { logError } from "../lib/error-logger.js";
 import { formatForSlack, prettifyAndWrapTable } from "../lib/format.js";
 import { TABLE_BLOCK_KEY } from "../tools/table.js";
 import { safePostMessage, isChannelTypeNotSupported, isInvalidBlocks, isMsgTooLong } from "../lib/slack-messaging.js";
-import { getSlackMeta, executionContext } from "../lib/tool.js";
+import { getSlackMeta, getToolDescription, executionContext } from "../lib/tool.js";
 import { createInteractiveAgent } from "../lib/agents.js";
 import { getMainModel, buildCachedSystemMessages } from "../lib/ai.js";
 
@@ -115,6 +115,22 @@ function buildToolMetadata(
 function truncate(s: string | undefined, max: number): string | undefined {
   if (!s) return undefined;
   return s.length <= max ? s : s.slice(0, max - 1) + "…";
+}
+
+function approvalAwaitingTitle(
+  toolDef: unknown,
+  toolName: string,
+  input: Record<string, unknown>,
+): string {
+  const slackMeta = getSlackMeta(toolDef);
+  const customApprovalStatus =
+    typeof slackMeta?.approvalStatus === "function"
+      ? slackMeta.approvalStatus(input)
+      : slackMeta?.approvalStatus;
+  const description = customApprovalStatus
+    ?? getToolDescription(toolDef)
+    ?? toolName;
+  return truncate(`Awaiting approval: ${description}`, 150) ?? "Awaiting approval";
 }
 
 
@@ -786,6 +802,45 @@ export async function generateResponse(
           });
 
           try {
+            const approvalToolDef = tools[approvalToolName];
+            const approvalSlackMeta = getSlackMeta(approvalToolDef);
+            const details = approvalSlackMeta?.detail?.(approvalInput);
+            if (approvalToolCallId) {
+              const awaitingPayload = {
+                chunks: [{
+                  type: "task_update",
+                  id: approvalToolCallId,
+                  title: approvalAwaitingTitle(
+                    approvalToolDef,
+                    approvalToolName,
+                    approvalInput as Record<string, unknown>,
+                  ),
+                  status: "pending",
+                  ...(details && { details }),
+                }],
+              };
+              currentStreamLength += estimateAppendSize(awaitingPayload);
+              if (!streamingFailed) {
+                await tryStreamAppend(awaitingPayload);
+                if (streamingFailed) {
+                  fallbackStartIdx = accumulatedText.length;
+                }
+              }
+            }
+
+            const pending = pendingToolInputs.get(approvalToolCallId);
+            toolCallRecords.push({
+              name: approvalToolName,
+              input: pending?.input ?? truncateToBytes(JSON.stringify(approvalInput), 1500),
+              output: "Awaiting human approval",
+              is_error: false,
+            });
+            if (approvalToolCallId) pendingToolInputs.delete(approvalToolCallId);
+
+            if (pendingToolInputs.size === 0 && toolKeepAlive) { clearInterval(toolKeepAlive); toolKeepAlive = null; }
+            if (pendingToolInputs.size === 0 && streamKeepAlive) { clearInterval(streamKeepAlive); streamKeepAlive = null; }
+            resetTimer();
+
             // Save conversation state for resumption after approval
             const { db } = await import("../db/client.js");
             const { actionLog } = await import("../db/schema.js");


### PR DESCRIPTION
## What this does
Implements all 3 phases from issue #45 to fix the confusing HITL approval UX.

### Phase 1: Tool card status
- Tool card now shows `status: "pending"` with title `"Awaiting approval: PUT https://..."` instead of rendering as `[ERROR]`
- Added `getToolDescription()` helper and `approvalStatus` slackMeta option for custom approval titles
- Properly records toolCallRecord as `is_error: false` and cleans up pendingToolInputs

### Phase 2: Approval message formatting
- Replaced raw JSON dump with human-readable summaries
- `http_request`: shows Method, URL, and truncated body (first 200 chars)
- Other tools: clean key-value list (max 12 entries)
- Added `Expires in 10 minutes` expiry context

### Phase 3: Post-decision message update
- After approval + execution: `chat.update` replaces the approval message with `Approved by @user` + result summary
- After rejection: updates message with `Rejected by @user`
- Falls back to posting a new message if update fails (e.g. channel/ts missing)
- Removed duplicate UI update code from `app.ts` button handlers -- now handled canonically in `hitl-resumption.ts`

## Files changed
- `src/pipeline/respond.ts` -- pending task_update + cleanup on approval
- `src/lib/approval.ts` -- human-readable param summaries
- `src/lib/hitl-resumption.ts` -- chat.update after approve/reject
- `src/lib/tool.ts` -- getToolDescription helper
- `src/app.ts` -- removed duplicate UI update code

## TypeScript
```
NODE_OPTIONS="--max-old-space-size=768" npx tsc --noEmit  # passes
```

Closes #45