### PR TITLE
fix: HITL UI -- shorter approval title + instant button feedback

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -637,6 +637,35 @@ app.post("/api/slack/interactions", async (c) => {
       // ── Governance approval buttons ─────────────────────────────────
       if (action.action_id?.startsWith("governance_approve_")) {
         const actionLogId = action.action_id.replace("governance_approve_", "");
+
+        // Immediately update the approval message to show "executing" state
+        const messageTs = payload.message?.ts;
+        const channelId = payload.channel?.id;
+        if (messageTs && channelId) {
+          const originalBlocks = (payload.message?.blocks ?? []) as any[];
+          // Remove the actions block (buttons) and update context to show executing
+          const updatedBlocks = originalBlocks
+            .filter((b: any) => b.type !== "actions")
+            .map((b: any) => {
+              if (b.type === "context") {
+                return {
+                  type: "context",
+                  elements: [{
+                    type: "mrkdwn",
+                    text: `:hourglass_flowing_sand: Approved by <@${userId}> -- executing now...`,
+                  }],
+                };
+              }
+              return b;
+            });
+          waitUntil(slackClient.chat.update({
+            channel: channelId,
+            ts: messageTs,
+            blocks: updatedBlocks,
+            text: `Approved by <@${userId}> -- executing...`,
+          }).catch((err: any) => logger.warn("Failed to update approval message", { err })));
+        }
+
         const approvePromise = (async () => {
           try {
             const { handleApprovalReaction } = await import("./lib/approval.js");
@@ -664,6 +693,34 @@ app.post("/api/slack/interactions", async (c) => {
 
       if (action.action_id?.startsWith("governance_reject_")) {
         const actionLogId = action.action_id.replace("governance_reject_", "");
+
+        // Immediately update the approval message to show rejected state
+        const rejectMessageTs = payload.message?.ts;
+        const rejectChannelId = payload.channel?.id;
+        if (rejectMessageTs && rejectChannelId) {
+          const originalBlocks = (payload.message?.blocks ?? []) as any[];
+          const updatedBlocks = originalBlocks
+            .filter((b: any) => b.type !== "actions")
+            .map((b: any) => {
+              if (b.type === "context") {
+                return {
+                  type: "context",
+                  elements: [{
+                    type: "mrkdwn",
+                    text: `:x: Rejected by <@${userId}>`,
+                  }],
+                };
+              }
+              return b;
+            });
+          waitUntil(slackClient.chat.update({
+            channel: rejectChannelId,
+            ts: rejectMessageTs,
+            blocks: updatedBlocks,
+            text: `Rejected by <@${userId}>`,
+          }).catch((err: any) => logger.warn("Failed to update rejection message", { err })));
+        }
+
         const rejectPromise = (async () => {
           try {
             const { handleApprovalReaction } = await import("./lib/approval.js");

--- a/src/pipeline/respond.ts
+++ b/src/pipeline/respond.ts
@@ -127,10 +127,10 @@ function approvalAwaitingTitle(
     typeof slackMeta?.approvalStatus === "function"
       ? slackMeta.approvalStatus(input)
       : slackMeta?.approvalStatus;
-  const description = customApprovalStatus
-    ?? getToolDescription(toolDef)
-    ?? toolName;
-  return truncate(`Awaiting approval: ${description}`, 150) ?? "Awaiting approval";
+  // Prefer: custom approvalStatus > detail() > toolName (never full description)
+  const detail = slackMeta?.detail?.(input);
+  const label = customApprovalStatus ?? detail ?? toolName;
+  return truncate(`Awaiting approval: ${label}`, 150) ?? "Awaiting approval";
 }
 
 


### PR DESCRIPTION
## Fixes

Two UX issues from testing:

### 1. Tool card title was showing full tool description
**Before:** `Awaiting approval: Make a credentialed HTTP request to an external API. The credential is injected server-side -- the LLM never sees the key value. U...`
**After:** `Awaiting approval: DELETE /api/v1/lead/lead_xxx`

Changed `approvalAwaitingTitle()` to prefer `detail()` from SlackToolMetadata (which returns e.g. `DELETE /url`) over the full tool description. Fallback chain: `approvalStatus > detail() > toolName`.

### 2. Approve/Reject buttons had no loading feedback
Clicking Approve/Reject did nothing visually -- the buttons stayed clickable until the async work finished.

Now: immediately on click, `chat.update` replaces the approval message -- removes buttons and shows:
- Approve: `:hourglass_flowing_sand: Approved by @user -- executing now...`
- Reject: `:x: Rejected by @user`

The async handler then updates the message again with the final result.

## Files changed
- `src/pipeline/respond.ts` -- `approvalAwaitingTitle()` uses detail() instead of description
- `src/app.ts` -- governance button handlers immediately update the message