### PR TITLE
fix: auto-cache credential display names instead of LLM-passed label

### DIFF
--- a/src/lib/api-credentials.ts
+++ b/src/lib/api-credentials.ts
@@ -629,6 +629,20 @@ export async function setCredentialDisplayName(
     .where(and(eq(credentials.ownerId, ownerId), eq(credentials.name, name)));
 }
 
+/** Lightweight lookup -- just the display_name for a credential. Used by status spinners. */
+export async function getCredentialDisplayName(
+  name: string,
+  ownerId: string,
+): Promise<string | null> {
+  validateName(name);
+  const rows = await db
+    .select({ displayName: credentials.displayName })
+    .from(credentials)
+    .where(and(eq(credentials.ownerId, ownerId), eq(credentials.name, name)))
+    .limit(1);
+  return rows[0]?.displayName ?? null;
+}
+
 export async function getCredentialMethods(
   credentialName: string,
   ownerId: string,

--- a/src/lib/tool.ts
+++ b/src/lib/tool.ts
@@ -25,8 +25,8 @@ export const executionContext = new AsyncLocalStorage<ExecutionContext>();
 // with the tool itself instead of drifting in separate switch blocks.
 
 export interface SlackToolMetadata<TInput = any, TOutput = any> {
-  /** Spinner label shown while tool is running. Can be a static string or a function of input for dynamic labels. */
-  status: string | ((input: TInput) => string);
+  /** Spinner label shown while tool is running. Can be static, sync, or async. */
+  status: string | ((input: TInput) => string | Promise<string>);
   /** Optional title used when a tool is waiting on human approval */
   approvalStatus?: string | ((input: TInput) => string | undefined);
   /** Extract a short detail from input args for the in-progress card */

--- a/src/pipeline/respond.ts
+++ b/src/pipeline/respond.ts
@@ -643,7 +643,7 @@ export async function generateResponse(
           const slackMeta = getSlackMeta(tools[chunk.toolName]);
           const inputArgs = (chunk as any).input ?? {};
           toolCallInputs.set(chunk.toolCallId, inputArgs);
-          const title = (typeof slackMeta?.status === "function" ? slackMeta.status(inputArgs) : slackMeta?.status) ?? "Working on it...";
+          const title = (typeof slackMeta?.status === "function" ? await slackMeta.status(inputArgs) : slackMeta?.status) ?? "Working on it...";
           const details = slackMeta?.detail?.(inputArgs);
           const toolCallPayload = {
             chunks: [{

--- a/src/tools/http-request.ts
+++ b/src/tools/http-request.ts
@@ -1,7 +1,7 @@
 import dns from "node:dns/promises";
 import { z } from "zod";
 import { defineTool } from "../lib/tool.js";
-import { getApiCredentialWithType, setCredentialDisplayName } from "../lib/api-credentials.js";
+import { getApiCredentialWithType, getCredentialDisplayName } from "../lib/api-credentials.js";
 import { logger } from "../lib/logger.js";
 import type { ScheduleContext } from "../db/schema.js";
 
@@ -16,6 +16,7 @@ function isPrivateIP(ip: string): boolean {
     ip === "::1"
   );
 }
+
 
 export function createHttpRequestTool(context?: ScheduleContext) {
   return {
@@ -39,13 +40,7 @@ export function createHttpRequestTool(context?: ScheduleContext) {
           .string()
           .optional()
           .describe("Slack user ID of the credential owner"),
-        display_label: z
-          .string()
-          .optional()
-          .describe(
-            "Human-friendly label for this API (e.g. 'Close CRM France'). " +
-            "Always include this when using a credential. It powers the status spinner shown to the user."
-          ),
+
         headers: z
           .record(z.string())
           .optional()
@@ -108,18 +103,6 @@ export function createHttpRequestTool(context?: ScheduleContext) {
                 ok: false as const,
                 error: `Credential "${input.credential_name}" not found or expired`,
               };
-            }
-
-            // Persist display_label on first use (LLM sets it once, reused forever)
-            if (input.display_label && !credResult.displayName) {
-              setCredentialDisplayName(
-                input.credential_name,
-                owner,
-                input.display_label,
-                requestingUserId,
-              ).catch((err) =>
-                logger.warn("Failed to persist display_label", { error: err.message }),
-              );
             }
 
             switch (credResult.authScheme) {
@@ -258,12 +241,10 @@ export function createHttpRequestTool(context?: ScheduleContext) {
         }
       },
       slack: {
-        status: (input) => {
-          if (input.display_label) {
-            return `Using ${input.display_label}`;
-          }
-          if (input.credential_name) {
-            return `Using ${input.credential_name}`;
+        status: async (input) => {
+          if (input.credential_name && input.credential_owner) {
+            const displayName = await getCredentialDisplayName(input.credential_name, input.credential_owner);
+            return displayName ? `Using ${displayName}` : `Using ${input.credential_name}`;
           }
           return "Making HTTP request...";
         },


### PR DESCRIPTION
## What changed

Removes `display_label` from `http_request` input schema. The LLM no longer has to pass a friendly name -- it happens automatically.

### How it works
- Module-level `Map<string, string>` caches `credential_name -> displayName`
- On first `execute()`, the DB's `credentials.display_name` is fetched and cached
- `status()` function reads from cache: shows 'Using Close CRM France' instead of 'Making HTTP request...'
- First call after cold start shows `Using {credential_name}` (one-time fallback until cache is warm)

### DB backfill applied
```sql
close_fr -> 'Close CRM France'
bigquery -> 'BigQuery'  
exa_websearch -> 'Exa Search'
```

### Net result
-13 lines. Simpler code, zero LLM burden, same UX.