### PR TITLE
fix: await async status in tool-result and tool-error handlers

### DIFF
--- a/src/pipeline/respond.ts
+++ b/src/pipeline/respond.ts
@@ -687,7 +687,7 @@ export async function generateResponse(
 
         case "tool-result": {
           const resultSlackMeta = getSlackMeta(tools[chunk.toolName]);
-          const title = (typeof resultSlackMeta?.status === "function" ? resultSlackMeta.status(toolCallInputs.get(chunk.toolCallId) ?? {}) : resultSlackMeta?.status) ?? "Done";
+          const title = (typeof resultSlackMeta?.status === "function" ? await resultSlackMeta.status(toolCallInputs.get(chunk.toolCallId) ?? {}) : resultSlackMeta?.status) ?? "Done";
           const output = chunk.output;
           const isError = output && typeof output === "object" &&
             "ok" in output && output.ok === false;
@@ -749,7 +749,7 @@ export async function generateResponse(
           const errToolName = (chunk as any).toolName;
           const errToolCallId = (chunk as any).toolCallId;
           const errSlackMeta = getSlackMeta(tools[errToolName]);
-          const title = (typeof errSlackMeta?.status === "function" ? errSlackMeta.status(toolCallInputs.get(errToolCallId) ?? {}) : errSlackMeta?.status) ?? "Failed";
+          const title = (typeof errSlackMeta?.status === "function" ? await errSlackMeta.status(toolCallInputs.get(errToolCallId) ?? {}) : errSlackMeta?.status) ?? "Failed";
           const err = (chunk as any).error;
           const errorMsg = err instanceof Error ? err.message : String(err);
           const toolErrorPayload = {


### PR DESCRIPTION
## Bug
After PR #54 made the `status` function async (for DB lookup of credential display names), the `tool-result` and `tool-error` handlers were passing an unresolved Promise as the title string. Slack rendered this as a red error icon even on successful requests.

## Fix
Add `await` to both handlers (lines 690 and 752). The `tool-call` handler already had it.

## Impact
- All `http_request` calls showed a red error icon on completion despite succeeding
- The title field contained `[object Promise]` instead of the resolved status string

Two-line change.