### PR TITLE
fix: await async status in tool-result and tool-error handlers

### DIFF
--- a/src/pipeline/respond.ts
+++ b/src/pipeline/respond.ts
@@ -687,7 +687,7 @@ export async function generateResponse(
 
         case "tool-result": {
           const resultSlackMeta = getSlackMeta(tools[chunk.toolName]);
-          const title = (typeof resultSlackMeta?.status === "function" ? resultSlackMeta.status(toolCallInputs.get(chunk.toolCallId) ?? {}) : resultSlackMeta?.status) ?? "Done";
+          const title = (typeof resultSlackMeta?.status === "function" ? await resultSlackMeta.status(toolCallInputs.get(chunk.toolCallId) ?? {}) : resultSlackMeta?.status) ?? "Done";
           const output = chunk.output;
           const isError = output && typeof output === "object" &&
             "ok" in output && output.ok === false;
@@ -749,7 +749,7 @@ export async function generateResponse(
           const errToolName = (chunk as any).toolName;
           const errToolCallId = (chunk as any).toolCallId;
           const errSlackMeta = getSlackMeta(tools[errToolName]);
-          const title = (typeof errSlackMeta?.status === "function" ? errSlackMeta.status(toolCallInputs.get(errToolCallId) ?? {}) : errSlackMeta?.status) ?? "Failed";
+          const title = (typeof errSlackMeta?.status === "function" ? await errSlackMeta.status(toolCallInputs.get(errToolCallId) ?? {}) : errSlackMeta?.status) ?? "Failed";
           const err = (chunk as any).error;
           const errorMsg = err instanceof Error ? err.message : String(err);
           const toolErrorPayload = {


### PR DESCRIPTION
## Bug
The `status` function on `http_request` was made async in PR #54 (for DB lookup of credential display names). But only the `tool-call` handler got the `await`. The `tool-result` and `tool-error` handlers passed an unresolved Promise as the title string to Slack's `task_update` chunk, causing Slack to render the card with a **red error icon even on successful requests**.

## Fix
Two-line change: add `await` to both the `tool-result` (line 690) and `tool-error` (line 752) handlers in `respond.ts`.

## Root cause
PR #54 widened the `status` type to `string | ((input) => string | Promise<string>)` but only updated one of the three call sites.