### PR TITLE
Approval card UX redesign

### DIFF
--- a/drizzle/0039_approval_summary_columns.sql
+++ b/drizzle/0039_approval_summary_columns.sql
@@ -1,0 +1,5 @@
+-- Add summary column to action_log for LLM-generated approval summaries
+ALTER TABLE "action_log" ADD COLUMN "summary" jsonb;
+
+-- Add description column to credentials for user-provided credential descriptions
+ALTER TABLE "credentials" ADD COLUMN "description" text;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -274,6 +274,13 @@
       "when": 1773292269439,
       "tag": "0038_credential_display_name",
       "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "7",
+      "when": 1773398400000,
+      "tag": "0039_approval_summary_columns",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -634,6 +634,136 @@ app.post("/api/slack/interactions", async (c) => {
         waitUntil(denyPromise);
       }
 
+      // ── Governance "View more" button ───────────────────────────────
+      if (action.action_id?.startsWith("governance_view_more_")) {
+        const actionLogId = action.action_id.replace("governance_view_more_", "");
+        const viewMorePromise = (async () => {
+          try {
+            const { actionLog } = await import("./db/schema.js");
+            const { db } = await import("./db/client.js");
+            const { eq } = await import("drizzle-orm");
+            
+            const rows = await db.select().from(actionLog).where(eq(actionLog.id, actionLogId)).limit(1);
+            const entry = rows[0];
+            
+            if (!entry) {
+              logger.warn("governance_view_more: action_log not found", { actionLogId });
+              return;
+            }
+
+            const summary = entry.summary as { title: string; body: string; fullExplanation: string } | null;
+            const fullExplanation = summary?.fullExplanation || "No detailed explanation available.";
+
+            await slackClient.views.open({
+              trigger_id: payload.trigger_id,
+              view: {
+                type: "modal",
+                title: { type: "plain_text", text: "Approval Details" },
+                close: { type: "plain_text", text: "Close" },
+                blocks: [
+                  {
+                    type: "header",
+                    text: { type: "plain_text", text: summary?.title || "Approval Request" },
+                  },
+                  {
+                    type: "section",
+                    text: { type: "mrkdwn", text: fullExplanation },
+                  },
+                  {
+                    type: "context",
+                    elements: [
+                      {
+                        type: "mrkdwn",
+                        text: `Tool: \`${entry.toolName}\` • Risk: \`${entry.riskTier}\` • ID: \`${actionLogId}\``,
+                      },
+                    ],
+                  },
+                ],
+              },
+            });
+          } catch (err) {
+            recordError("interactions.governance_view_more", err, { userId, actionLogId });
+            logger.error("View more modal failed", { userId, actionLogId, error: err });
+          }
+        })();
+        waitUntil(viewMorePromise);
+      }
+
+      // ── Governance "View raw" button (admin-only) ────────────────────
+      if (action.action_id?.startsWith("governance_view_raw_")) {
+        const actionLogId = action.action_id.replace("governance_view_raw_", "");
+        
+        // Check admin permission
+        if (!userId || !isAdmin(userId)) {
+          logger.warn("Non-admin attempted to view raw approval data", { userId, actionLogId });
+          const ephemeralPromise = (async () => {
+            try {
+              await slackClient.chat.postEphemeral({
+                channel: payload.channel?.id,
+                user: userId,
+                text: "⚠️ Only admins can view raw approval payloads.",
+              });
+            } catch { /* best effort */ }
+          })();
+          waitUntil(ephemeralPromise);
+          continue;
+        }
+
+        const viewRawPromise = (async () => {
+          try {
+            const { actionLog } = await import("./db/schema.js");
+            const { db } = await import("./db/client.js");
+            const { eq } = await import("drizzle-orm");
+            
+            const rows = await db.select().from(actionLog).where(eq(actionLog.id, actionLogId)).limit(1);
+            const entry = rows[0];
+            
+            if (!entry) {
+              logger.warn("governance_view_raw: action_log not found", { actionLogId });
+              return;
+            }
+
+            const rawPayload = JSON.stringify(entry.params, null, 2);
+            const truncated = rawPayload.length > 2900 ? rawPayload.slice(0, 2900) + "\n\n...(truncated)" : rawPayload;
+
+            await slackClient.views.open({
+              trigger_id: payload.trigger_id,
+              view: {
+                type: "modal",
+                title: { type: "plain_text", text: "Raw Payload" },
+                close: { type: "plain_text", text: "Close" },
+                blocks: [
+                  {
+                    type: "header",
+                    text: { type: "plain_text", text: "Developer Payload" },
+                  },
+                  {
+                    type: "section",
+                    text: {
+                      type: "mrkdwn",
+                      text: `\`\`\`\n${truncated}\n\`\`\``,
+                    },
+                  },
+                  {
+                    type: "context",
+                    elements: [
+                      {
+                        type: "mrkdwn",
+                        text: `Tool: \`${entry.toolName}\` • Triggered by: <@${entry.triggeredBy}> • ID: \`${actionLogId}\``,
+                      },
+                    ],
+                  },
+                ],
+              },
+            });
+          } catch (err) {
+            recordError("interactions.governance_view_raw", err, { userId, actionLogId });
+            logger.error("View raw modal failed", { userId, actionLogId, error: err });
+          }
+        })();
+        waitUntil(viewRawPromise);
+      }
+
       // ── Governance approval buttons ─────────────────────────────────
       if (action.action_id?.startsWith("governance_approve_")) {
         const actionLogId = action.action_id.replace("governance_approve_", "");
@@ -822,6 +952,7 @@ function extractCredentialValue(
     if (callbackId === "api_credential_add_submit" && userId) {
       if (!isAdmin(userId)) return c.json({});
       const name = payload.view?.state?.values?.cred_name_block?.cred_name?.value;
+      const description = payload.view?.state?.values?.cred_description_block?.cred_description?.value;
       const expiryStr = payload.view?.state?.values?.cred_expiry_block?.cred_expiry?.selected_date;
       const authScheme = (payload.view?.state?.values?.cred_auth_scheme_block?.cred_auth_scheme?.selected_option?.value || "bearer") as
         | "bearer"
@@ -838,7 +969,7 @@ function extractCredentialValue(
         const expiresAt = expiryStr ? new Date(expiryStr) : undefined;
         const addPromise = (async () => {
           try {
-            await storeApiCredential(userId, name, value, expiresAt, authScheme);
+            await storeApiCredential(userId, name, value, expiresAt, authScheme, description);
             await publishHomeTab(slackClient, userId);
           } catch (err) {
             recordError("interactions.api_credential_add", err, { userId, name });
@@ -870,6 +1001,7 @@ function extractCredentialValue(
 
     if (callbackId === "api_credential_update_submit" && userId) {
       const credentialId = payload.view?.private_metadata;
+      const description = payload.view?.state?.values?.cred_description_block?.cred_description?.value;
       const authScheme = (payload.view?.state?.values?.cred_auth_scheme_block?.cred_auth_scheme?.selected_option?.value || "bearer") as
         | "bearer"
         | "basic"
@@ -903,6 +1035,7 @@ function extractCredentialValue(
               value,
               cred.expires_at ?? undefined,
               authScheme,
+              description,
             );
             await publishHomeTab(slackClient, userId);
           } catch (err) {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -555,6 +555,11 @@ export const actionLog = pgTable(
     approvedBy: text("approved_by"),
     approvedAt: timestamptz("approved_at"),
     idempotencyKey: text("idempotency_key"),
+    summary: jsonb("summary").$type<{
+      title: string;
+      body: string;
+      fullExplanation: string;
+    }>(),
     // HITL resumption fields
     conversationState: jsonb("conversation_state").$type<{
       channelId: string;
@@ -705,6 +710,7 @@ export const credentials = pgTable(
     keyVersion: integer("key_version").notNull().default(1),
     allowedMethods: text("allowed_methods").array(),
     displayName: text("display_name"),
+    description: text("description"),
     expiresAt: timestamptz("expires_at"),
     createdAt: timestamptz("created_at").notNull().defaultNow(),
     updatedAt: timestamptz("updated_at").notNull().defaultNow(),

--- a/src/lib/api-credentials.ts
+++ b/src/lib/api-credentials.ts
@@ -118,6 +118,7 @@ export async function storeApiCredential(
   plaintext: string,
   expiresAt?: Date,
   authScheme: AuthScheme = "bearer",
+  description?: string,
 ): Promise<Credential> {
   validateKey();
   validateName(name);
@@ -188,6 +189,7 @@ export async function storeApiCredential(
       authScheme,
       value: encrypted,
       expiresAt: expiresAt ?? null,
+      description: description ?? null,
     })
     .onConflictDoUpdate({
       target: [credentials.ownerId, credentials.name],
@@ -195,6 +197,7 @@ export async function storeApiCredential(
         value: encrypted,
         authScheme,
         expiresAt: expiresAt ?? null,
+        description: description ?? null,
         updatedAt: new Date(),
       },
     })

--- a/src/lib/approval.ts
+++ b/src/lib/approval.ts
@@ -9,6 +9,8 @@ import {
   type ScheduleContext,
 } from "../db/schema.js";
 import { logger } from "./logger.js";
+import { generateText } from "ai";
+import { getMainModel } from "./ai.js";
 
 export type { ApprovalPolicy };
 
@@ -184,6 +186,67 @@ function summarizeToolParams(toolName: string, params: unknown): string {
   return lines.join("\n");
 }
 
+// ── LLM-Generated Approval Summary ──────────────────────────────────────────
+
+/**
+ * Generate a human-readable approval summary using the LLM.
+ * Returns a compact title + body for the card, plus a full explanation for the modal.
+ */
+async function generateApprovalSummary(args: {
+  toolName: string;
+  params: unknown;
+  riskTier: string;
+}): Promise<{ title: string; body: string; fullExplanation: string }> {
+  const { toolName, params, riskTier } = args;
+
+  try {
+    const { model } = await getMainModel();
+    
+    const prompt = `You are helping a human understand what an AI agent is requesting approval to do.
+
+Tool: ${toolName}
+Risk tier: ${riskTier}
+Parameters: ${JSON.stringify(params, null, 2)}
+
+Generate a human-readable summary with:
+1. A short title (5-10 words max) - what action is being requested
+2. A body (1-2 sentences) - key details the approver needs to know
+3. A full explanation (2-3 paragraphs) - complete context including why this might need approval, what the parameters mean, and potential impact
+
+Format as JSON:
+{
+  "title": "...",
+  "body": "...",
+  "fullExplanation": "..."
+}`;
+
+    const result = await generateText({
+      model,
+      prompt,
+      temperature: 0.3,
+    });
+
+    const parsed = JSON.parse(result.text);
+    return {
+      title: parsed.title || `Approval: ${toolName}`,
+      body: parsed.body || "Review the parameters before approving.",
+      fullExplanation: parsed.fullExplanation || result.text,
+    };
+  } catch (error) {
+    logger.warn("Failed to generate LLM approval summary, using fallback", {
+      toolName,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    
+    // Fallback to basic summary
+    return {
+      title: `Approval: ${toolName}`,
+      body: `Risk tier: ${riskTier}. Review parameters before approving.`,
+      fullExplanation: `This request requires approval because it's classified as ${riskTier} risk.\n\nTool: ${toolName}\n\nParameters:\n${JSON.stringify(params, null, 2)}`,
+    };
+  }
+}
+
 // ── Request Approval (post Slack message + write action_log row) ────────────
 
 export async function requestApproval(args: {
@@ -209,6 +272,19 @@ export async function requestApproval(args: {
     throw new Error(`action_log row ${actionLogId} not found`);
   }
 
+  // Generate LLM summary
+  const summary = await generateApprovalSummary({
+    toolName,
+    params: logEntry.params ?? params,
+    riskTier,
+  });
+
+  // Store summary in action_log
+  await db
+    .update(actionLog)
+    .set({ summary })
+    .where(eq(actionLog.id, actionLogId));
+
   const channel = policy?.approvalChannel ?? undefined;
   const approvers = policy?.approverIds ?? [];
   const approverMentions =
@@ -216,28 +292,31 @@ export async function requestApproval(args: {
       ? approvers.map((id) => `<@${id}>`).join(", ")
       : "admins";
 
+  // Color based on risk tier
+  const colorMap: Record<string, string> = {
+    read: "#36A64F",        // green
+    write: "#FFB900",       // yellow
+    destructive: "#D32F2F", // red
+  };
+  const color = colorMap[riskTier] ?? "#FFB900";
+
+  // Build compact card with attachment
   const blocks = [
     {
-      type: "header" as const,
-      text: {
-        type: "plain_text" as const,
-        text: `🔒 Approval Required: ${toolName}`,
-        emoji: true,
-      },
-    },
-    {
       type: "section" as const,
       text: {
         type: "mrkdwn" as const,
-        text: `*Risk tier:* \`${riskTier}\`\n*Requested by:* <@${logEntry.triggeredBy}>\n*Trigger:* ${logEntry.triggerType}${logEntry.jobId ? `\n*Job:* ${logEntry.jobId}` : ""}`,
+        text: `*${summary.title}*\n${summary.body}`,
       },
     },
     {
-      type: "section" as const,
-      text: {
-        type: "mrkdwn" as const,
-        text: `*Request details:*\n${summarizeToolParams(toolName, logEntry.params ?? params)}`,
-      },
+      type: "context" as const,
+      elements: [
+        {
+          type: "mrkdwn" as const,
+          text: `Risk: \`${riskTier}\` • Requested by <@${logEntry.triggeredBy}>`,
+        },
+      ],
     },
     {
       type: "actions" as const,
@@ -254,6 +333,18 @@ export async function requestApproval(args: {
           text: { type: "plain_text" as const, text: "❌ Reject", emoji: true },
           style: "danger" as const,
           action_id: `governance_reject_${actionLogId}`,
+          value: actionLogId,
+        },
+        {
+          type: "button" as const,
+          text: { type: "plain_text" as const, text: "📋 View more", emoji: true },
+          action_id: `governance_view_more_${actionLogId}`,
+          value: actionLogId,
+        },
+        {
+          type: "button" as const,
+          text: { type: "plain_text" as const, text: "🔍 View raw", emoji: true },
+          action_id: `governance_view_raw_${actionLogId}`,
           value: actionLogId,
         },
       ],
@@ -285,8 +376,13 @@ export async function requestApproval(args: {
   const result = await slackClient.chat.postMessage({
     channel: targetChannel,
     ...(context.threadTs ? { thread_ts: context.threadTs } : {}),
-    text: `Approval required for ${toolName} (${riskTier})`,
-    blocks,
+    text: `🔒 Approval Required: ${summary.title}`,
+    attachments: [
+      {
+        color,
+        blocks,
+      },
+    ],
     metadata: {
       event_type: "approval_request",
       event_payload: {

--- a/src/pipeline/respond.ts
+++ b/src/pipeline/respond.ts
@@ -819,7 +819,7 @@ export async function generateResponse(
                     approvalToolName,
                     approvalInput as Record<string, unknown>,
                   ),
-                  status: "pending",
+                  status: "in_progress",
                   ...(details && { details }),
                 }],
               };

--- a/src/slack/home.ts
+++ b/src/slack/home.ts
@@ -499,6 +499,18 @@ export function buildAddCredentialBlocks(authScheme: AuthScheme = "bearer"): any
         text: "Lowercase, a-z, 0-9, underscores. e.g. airbyte_api_token",
       },
     },
+    {
+      type: "input",
+      block_id: "cred_description_block",
+      label: { type: "plain_text", text: "Description (optional)" },
+      optional: true,
+      element: {
+        type: "plain_text_input",
+        action_id: "cred_description",
+        placeholder: { type: "plain_text", text: "What is this credential used for?" },
+        multiline: true,
+      },
+    },
     authSchemeBlock,
     ...valueBlocks,
     {
@@ -519,7 +531,22 @@ export function buildUpdateCredentialBlocks(authScheme: AuthScheme = "bearer"): 
   const authSchemeBlock = buildAuthSchemeBlock(authScheme);
   const valueBlocks = buildCredentialValueBlocks(authScheme);
 
-  return [authSchemeBlock, ...valueBlocks];
+  return [
+    {
+      type: "input",
+      block_id: "cred_description_block",
+      label: { type: "plain_text", text: "Description (optional)" },
+      optional: true,
+      element: {
+        type: "plain_text_input",
+        action_id: "cred_description",
+        placeholder: { type: "plain_text", text: "What is this credential used for?" },
+        multiline: true,
+      },
+    },
+    authSchemeBlock,
+    ...valueBlocks,
+  ];
 }
 
 export async function openAddCredentialModal(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implement Approval Card UX Redesign (Issue #57) to replace raw HTTP parameters with LLM-generated human-readable summaries and introduce a three-layer user experience.

This PR enhances approval cards by:
- Adding `summary` (LLM-generated title, body, full explanation) to `action_log` and `description` to `credentials` in the database, along with a new migration.
- Introducing `generateApprovalSummary()` to create human-readable summaries for approval requests.
- Rewriting `requestApproval()` to use Slack attachments with colored borders and LLM-generated content.
- Adding "View more" and "View raw" button handlers in `src/app.ts` to display detailed and raw payload modals, respectively.
- Fixing the tool-approval-request status from "pending" to "in_progress" in `src/pipeline/respond.ts`.
- Updating credential add/edit modals in `src/slack/home.ts` to include an optional description field.

<div><a href="https://cursor.com/agents/bc-d6426ed9-b64a-4d0e-b3cd-923a9faa865c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6426ed9-b64a-4d0e-b3cd-923a9faa865c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->