### PR TITLE
perf: increase heartbeat frequency from 30min to 10min

### DIFF
--- a/src/cron/execute-job.ts
+++ b/src/cron/execute-job.ts
@@ -13,8 +13,8 @@ const slackClient = new WebClient(botToken);
 /** Max retries before marking as failed */
 export const MAX_RETRIES = 3;
 
-/** Retry delay in ms (30 minutes — matches heartbeat cron interval) */
-const RETRY_DELAY_MS = 30 * 60 * 1000;
+/** Retry delay in ms (10 minutes — matches heartbeat cron interval) */
+const RETRY_DELAY_MS = 10 * 60 * 1000;
 
 // ── System Prompts ───────────────────────────────────────────────────────────
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "installCommand": "npm install",
-  "buildCommand": "tsc & P1=$!; tsx src/db/migrate.ts & P2=$!; wait $P1; R1=$?; wait $P2; R2=$?; [ $R1 -eq 0 ] && [ $R2 -eq 0 ]",
+  "buildCommand": "tsc & P1=$!; tsx src/db/migrate.ts & P2=$!; wait $P1; E1=$?; wait $P2; E2=$?; [ $E1 -eq 0 ] && [ $E2 -eq 0 ]",
   "framework": null,
   "regions": [
     "fra1"
@@ -31,8 +31,7 @@
     },
     {
       "path": "/api/cron/heartbeat",
-      "schedule": "*/30 * * * *"
+      "schedule": "*/10 * * * *"
     }
-  ],
-  "buildCommand": "tsc & P1=$!; tsx src/db/migrate.ts & P2=$!; wait $P1; E1=$?; wait $P2; E2=$?; [ $E1 -eq 0 ] && [ $E2 -eq 0 ]"
+  ]
 }


### PR DESCRIPTION
Jobs were waiting up to 30min to be picked up after creation. This reduces the heartbeat cron from `*/30` to `*/10` so jobs fire within ~10 minutes max.

Also updates the retry delay constant to match (30min -> 10min).

Two-line change in `vercel.json` + `execute-job.ts`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration/timing change; main impact is increased cron/job execution frequency and faster retry cycling, which could raise load if jobs are heavy.
> 
> **Overview**
> Increases the `heartbeat` cron frequency in `vercel.json` from every 30 minutes to every 10 minutes so pending jobs are picked up sooner.
> 
> Updates `execute-job.ts` retry backoff (`RETRY_DELAY_MS`) to 10 minutes to stay aligned with the new heartbeat interval, and makes a small variable rename in the Vercel `buildCommand` error-code capture.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a36656cc7b23e15fe0bc5d974ae9ffb0046fc4c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->