### PR TITLE
sync: merge upstream AuraHQ-ai/aura (Mar 13)

### DIFF
--- a/apps/api/src/cron/execute-job.ts
+++ b/apps/api/src/cron/execute-job.ts
@@ -14,8 +14,10 @@ import {
   persistConversationSteps,
   persistConversationError,
   updateConversationTraceUsage,
-  type Step as ConversationStep,
+  buildConversationSteps,
 } from "./persist-conversation.js";
+import { buildStepUsages } from "../lib/cost-calculator.js";
+import type { DetailedTokenUsage } from "@aura/db/schema";
 
 const botToken = process.env.SLACK_BOT_TOKEN || "";
 const slackClient = new WebClient(botToken);
@@ -212,21 +214,7 @@ export async function executeJob(
     const { text, steps, totalUsage: usage } = generateResult;
 
     // Phase 2a: persist assistant steps now that generate succeeded
-    const conversationSteps: ConversationStep[] = steps.map((step) => ({
-      text: step.text,
-      reasoning: (step as any).reasoning,
-      toolCalls: step.toolCalls?.map((tc) => ({
-        toolCallId: tc.toolCallId,
-        toolName: tc.toolName,
-        input: tc.input,
-      })),
-      toolResults: step.toolResults?.map((tr) => ({
-        toolCallId: tr.toolCallId,
-        toolName: tr.toolName,
-        output: tr.output,
-      })),
-      finishReason: step.finishReason,
-    }));
+    const conversationSteps = buildConversationSteps(steps);
     await persistConversationSteps(conversationId, conversationSteps, conversationOrderIndex);
 
     const serializedSteps = steps.map((step) => ({
@@ -242,14 +230,18 @@ export async function executeJob(
       })),
     }));
 
-    const tokenUsage = {
+    const tokenUsage: DetailedTokenUsage = {
       inputTokens: usage.inputTokens ?? 0,
       outputTokens: usage.outputTokens ?? 0,
       totalTokens: usage.totalTokens ?? 0,
+      inputTokenDetails: usage.inputTokenDetails,
+      outputTokenDetails: usage.outputTokenDetails,
     };
 
-    // Update trace with token usage
-    await updateConversationTraceUsage(conversationId, tokenUsage);
+    const stepUsages = buildStepUsages(steps);
+
+    // Update trace with token usage + cost
+    await updateConversationTraceUsage(conversationId, tokenUsage, stepUsages);
 
     // Update execution trace with results
     await db

--- a/apps/api/src/cron/persist-conversation.ts
+++ b/apps/api/src/cron/persist-conversation.ts
@@ -1,7 +1,8 @@
 import { eq } from "drizzle-orm";
 import { db } from "../db/client.js";
-import { conversationTraces, conversationMessages, conversationParts } from "@aura/db/schema";
+import { conversationTraces, conversationMessages, conversationParts, type DetailedTokenUsage } from "@aura/db/schema";
 import { logger } from "../lib/logger.js";
+import { computeConversationCost, type StepUsage } from "../lib/cost-calculator.js";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -23,6 +24,8 @@ export interface Step {
   toolCalls?: ToolCall[];
   toolResults?: ToolResult[];
   finishReason?: string;
+  modelId?: string;
+  usage?: DetailedTokenUsage;
 }
 
 type PartRow = {
@@ -69,6 +72,8 @@ function insertMessage(
   orderIndex: number,
   parts: PartRow[],
   content?: string | null,
+  modelId?: string | null,
+  tokenUsage?: DetailedTokenUsage | null,
 ) {
   const msgId = crypto.randomUUID();
 
@@ -78,6 +83,8 @@ function insertMessage(
     role,
     content: content ?? null,
     orderIndex,
+    modelId: modelId ?? null,
+    tokenUsage: tokenUsage ?? null,
   });
 
   if (parts.length === 0) return msgInsert;
@@ -131,6 +138,35 @@ function stepToParts(step: Step): PartRow[] {
   return parts;
 }
 
+/**
+ * Map raw AI SDK steps to ConversationStep (Step) objects for persistence.
+ */
+export function buildConversationSteps(rawSteps: any[]): Step[] {
+  return rawSteps.map((step: any) => ({
+    text: step.text,
+    reasoning: Array.isArray(step.reasoning) ? step.reasoning : undefined,
+    toolCalls: step.toolCalls?.map((tc: any) => ({
+      toolCallId: tc.toolCallId,
+      toolName: tc.toolName,
+      input: tc.input,
+    })),
+    toolResults: step.toolResults?.map((tr: any) => ({
+      toolCallId: tr.toolCallId,
+      toolName: tr.toolName,
+      output: tr.output,
+    })),
+    finishReason: step.finishReason,
+    modelId: step.response?.modelId,
+    usage: step.usage ? {
+      inputTokens: step.usage.inputTokens ?? 0,
+      outputTokens: step.usage.outputTokens ?? 0,
+      totalTokens: step.usage.totalTokens ?? 0,
+      inputTokenDetails: step.usage.inputTokenDetails,
+      outputTokenDetails: step.usage.outputTokenDetails,
+    } : undefined,
+  }));
+}
+
 // ── Phase 1: Persist inputs BEFORE generate ──────────────────────────────────
 // Saves system + user messages immediately so they survive crashes.
 // Returns the next orderIndex for assistant messages.
@@ -168,8 +204,17 @@ export async function persistConversationSteps(
 ): Promise<void> {
   try {
     for (let i = 0; i < steps.length; i++) {
-      const parts = stepToParts(steps[i]);
-      await insertMessage(conversationId, "assistant", startOrderIndex + i, parts);
+      const step = steps[i];
+      const parts = stepToParts(step);
+      await insertMessage(
+        conversationId,
+        "assistant",
+        startOrderIndex + i,
+        parts,
+        undefined,
+        step.modelId,
+        step.usage,
+      );
     }
 
     logger.info("persistConversationSteps: saved", {
@@ -221,12 +266,29 @@ export async function persistConversationError(
 
 export async function updateConversationTraceUsage(
   conversationId: string,
-  tokenUsage: { inputTokens: number; outputTokens: number; totalTokens: number },
+  tokenUsage: DetailedTokenUsage,
+  stepUsages?: StepUsage[],
 ): Promise<void> {
   try {
+    let costUsd: string | null = null;
+    if (stepUsages && stepUsages.length > 0) {
+      try {
+        const cost = await computeConversationCost(stepUsages);
+        if (cost > 0) costUsd = cost.toFixed(6);
+      } catch (costErr: any) {
+        logger.warn("updateConversationTraceUsage: cost computation failed (non-fatal)", {
+          conversationId,
+          error: costErr.message,
+        });
+      }
+    }
+
     await db
       .update(conversationTraces)
-      .set({ tokenUsage })
+      .set({
+        tokenUsage,
+        ...(costUsd != null && { costUsd }),
+      })
       .where(eq(conversationTraces.id, conversationId));
   } catch (err: any) {
     logger.error("updateConversationTraceUsage: failed (non-fatal)", {

--- a/apps/api/src/lib/cost-calculator.ts
+++ b/apps/api/src/lib/cost-calculator.ts
@@ -1,0 +1,173 @@
+import { and, eq, lte, gte, or, isNull } from "drizzle-orm";
+import { db } from "../db/client.js";
+import { modelPricing, type DetailedTokenUsage } from "@aura/db/schema";
+import { logger } from "./logger.js";
+
+export interface StepUsage {
+  modelId: string;
+  usage: DetailedTokenUsage;
+}
+
+interface PricingRow {
+  tokenType: string;
+  pricePerMillion: string;
+}
+
+const pricingCache = new Map<string, PricingRow[]>();
+
+/**
+ * Normalize a model ID for pricing lookup.
+ * The AI SDK gateway returns IDs like "anthropic/claude-sonnet-4-20250514"
+ * while step.response.modelId may return just "claude-sonnet-4-20250514".
+ * We strip the provider prefix and the date suffix for flexible matching.
+ */
+function normalizeModelId(modelId: string): string[] {
+  const stripped = modelId.replace(/^[^/]+\//, "");
+  const withoutDate = stripped.replace(/-\d{8}$/, "");
+  const candidates = [modelId, stripped, withoutDate];
+  if (modelId.includes("/")) {
+    const prefix = modelId.split("/")[0];
+    candidates.push(`${prefix}/${withoutDate}`);
+  }
+  return [...new Set(candidates)];
+}
+
+async function lookupPricing(
+  modelId: string,
+  asOfDate: Date,
+): Promise<PricingRow[]> {
+  const cacheKey = `${modelId}:${asOfDate.toISOString().slice(0, 10)}`;
+  if (pricingCache.has(cacheKey)) return pricingCache.get(cacheKey)!;
+
+  const candidates = normalizeModelId(modelId);
+
+  for (const candidate of candidates) {
+    const rows = await db
+      .select({
+        tokenType: modelPricing.tokenType,
+        pricePerMillion: modelPricing.pricePerMillion,
+      })
+      .from(modelPricing)
+      .where(
+        and(
+          eq(modelPricing.modelId, candidate),
+          lte(modelPricing.effectiveFrom, asOfDate),
+          or(
+            isNull(modelPricing.effectiveUntil),
+            gte(modelPricing.effectiveUntil, asOfDate),
+          ),
+        ),
+      );
+
+    if (rows.length > 0) {
+      pricingCache.set(cacheKey, rows);
+      return rows;
+    }
+  }
+
+  pricingCache.set(cacheKey, []);
+  return [];
+}
+
+function getPrice(
+  rows: PricingRow[],
+  tokenType: string,
+): number {
+  const row = rows.find((r) => r.tokenType === tokenType);
+  return row ? parseFloat(row.pricePerMillion) : 0;
+}
+
+/**
+ * Compute cost for a single step's usage given its pricing rows.
+ */
+function computeStepCost(
+  usage: DetailedTokenUsage,
+  pricing: PricingRow[],
+): number {
+  if (pricing.length === 0) return 0;
+
+  const inputPrice = getPrice(pricing, "input");
+  const cacheReadPrice = getPrice(pricing, "cache_read");
+  const cacheWritePrice = getPrice(pricing, "cache_write");
+  const outputPrice = getPrice(pricing, "output");
+  const reasoningPrice = getPrice(pricing, "reasoning");
+
+  let inputCost: number;
+  const id = usage.inputTokenDetails;
+  if (
+    id &&
+    (id.noCacheTokens != null ||
+      id.cacheReadTokens != null ||
+      id.cacheWriteTokens != null)
+  ) {
+    const cacheReadTokens = id.cacheReadTokens ?? 0;
+    const cacheWriteTokens = id.cacheWriteTokens ?? 0;
+    const noCacheTokens = id.noCacheTokens ?? Math.max(0, (usage.inputTokens ?? 0) - cacheReadTokens - cacheWriteTokens);
+    inputCost =
+      (noCacheTokens * inputPrice +
+        cacheReadTokens * cacheReadPrice +
+        cacheWriteTokens * cacheWritePrice) /
+      1_000_000;
+  } else {
+    inputCost = ((usage.inputTokens ?? 0) * inputPrice) / 1_000_000;
+  }
+
+  let outputCost: number;
+  const od = usage.outputTokenDetails;
+  if (od && (od.textTokens != null || od.reasoningTokens != null)) {
+    const textTokens = od.textTokens ?? 0;
+    const reasoningTokens = od.reasoningTokens ?? 0;
+    outputCost =
+      (textTokens * outputPrice + reasoningTokens * reasoningPrice) /
+      1_000_000;
+  } else {
+    outputCost = ((usage.outputTokens ?? 0) * outputPrice) / 1_000_000;
+  }
+
+  return inputCost + outputCost;
+}
+
+/**
+ * Build per-step usage data from raw AI SDK steps.
+ * Filters to steps that have both a modelId and usage, then maps to StepUsage[].
+ */
+export function buildStepUsages(rawSteps: any[]): StepUsage[] {
+  return rawSteps
+    .filter((step: any) => step.response?.modelId && step.usage)
+    .map((step: any) => ({
+      modelId: step.response.modelId,
+      usage: {
+        inputTokens: step.usage.inputTokens ?? 0,
+        outputTokens: step.usage.outputTokens ?? 0,
+        totalTokens: step.usage.totalTokens ?? 0,
+        inputTokenDetails: step.usage.inputTokenDetails,
+        outputTokenDetails: step.usage.outputTokenDetails,
+      },
+    }));
+}
+
+/**
+ * Compute total cost in USD for an array of steps.
+ * Looks up pricing for each model and computes:
+ *   Σ (token_count × price_per_million / 1_000_000) across all token types per step.
+ */
+export async function computeConversationCost(
+  steps: StepUsage[],
+  asOfDate: Date = new Date(),
+): Promise<number> {
+  let totalCost = 0;
+
+  for (const step of steps) {
+    try {
+      const pricing = await lookupPricing(step.modelId, asOfDate);
+      totalCost += computeStepCost(step.usage, pricing);
+    } catch (err: any) {
+      logger.warn("Cost calculation failed for step (non-fatal)", {
+        modelId: step.modelId,
+        error: err.message,
+      });
+    }
+  }
+
+  return totalCost;
+}

--- a/apps/api/src/pipeline/index.ts
+++ b/apps/api/src/pipeline/index.ts
@@ -39,8 +39,10 @@ import {
   persistConversationInputs,
   persistConversationSteps,
   updateConversationTraceUsage,
-  type Step as ConversationStep,
+  buildConversationSteps,
 } from "../cron/persist-conversation.js";
+import { buildStepUsages, type StepUsage } from "../lib/cost-calculator.js";
+import type { DetailedTokenUsage } from "@aura/db/schema";
 import type { SlackEvent } from "./context.js";
 
 /** Maximum message length we'll process (characters). Slack max is ~40k. */
@@ -579,23 +581,6 @@ async function handleTransparencyCommands(
 
 const STEPS_PROMISE_TIMEOUT_MS = 5_000;
 
-function mapRawStepsToConversationSteps(rawSteps: any[]): ConversationStep[] {
-  return rawSteps.map((step: any) => ({
-    text: step.text,
-    reasoning: Array.isArray(step.reasoning) ? step.reasoning : undefined,
-    toolCalls: step.toolCalls?.map((tc: any) => ({
-      toolCallId: tc.toolCallId,
-      toolName: tc.toolName,
-      input: tc.input,
-    })),
-    toolResults: step.toolResults?.map((tr: any) => ({
-      toolCallId: tr.toolCallId,
-      toolName: tr.toolName,
-      output: tr.output,
-    })),
-    finishReason: step.finishReason,
-  }));
-}
 
 async function persistConversationTrace(params: {
   channelId: string;
@@ -605,7 +590,7 @@ async function persistConversationTrace(params: {
   systemPrompt: string;
   userPrompt: string;
   stepsPromise?: PromiseLike<any[]>;
-  usage?: { inputTokens: number; outputTokens: number; totalTokens: number };
+  usage?: DetailedTokenUsage;
   stepsTimeoutMs?: number;
 }): Promise<string> {
   const { channelId, threadTs, userId, modelId, systemPrompt, userPrompt, stepsPromise, usage, stepsTimeoutMs } = params;
@@ -620,6 +605,7 @@ async function persistConversationTrace(params: {
 
   const orderIndex = await persistConversationInputs(conversationId, systemPrompt, userPrompt);
 
+  let stepUsages: StepUsage[] = [];
   if (stepsPromise) {
     try {
       let rawSteps: any[];
@@ -636,8 +622,9 @@ async function persistConversationTrace(params: {
       } else {
         rawSteps = await stepsPromise;
       }
-      const conversationSteps = mapRawStepsToConversationSteps(rawSteps);
+      const conversationSteps = buildConversationSteps(rawSteps);
       await persistConversationSteps(conversationId, conversationSteps, orderIndex);
+      stepUsages = buildStepUsages(rawSteps);
     } catch (stepsErr: any) {
       logger.error("Failed to persist conversation steps (non-fatal)", {
         conversationId,
@@ -647,7 +634,7 @@ async function persistConversationTrace(params: {
   }
 
   if (usage) {
-    await updateConversationTraceUsage(conversationId, usage);
+    await updateConversationTraceUsage(conversationId, usage, stepUsages);
   }
 
   return conversationId;
@@ -779,7 +766,7 @@ async function runBackgroundTasks(params: {
   threadMessageCount: number;
   recentThreadMessages: Array<{ displayName: string; text: string }>;
   threadMessagesElided: boolean;
-  tokenUsage?: { inputTokens: number; outputTokens: number; totalTokens: number };
+  tokenUsage?: DetailedTokenUsage;
   modelId?: string;
   systemPrompt?: string;
   userPrompt?: string;

--- a/apps/api/src/pipeline/respond.ts
+++ b/apps/api/src/pipeline/respond.ts
@@ -10,6 +10,7 @@ import { getSlackMeta, getToolDescription, executionContext } from "../lib/tool.
 import { createInteractiveAgent } from "../lib/agents.js";
 import { getMainModel, buildCachedSystemMessages } from "../lib/ai.js";
 import { InvocationSupersededError } from "./prepare-step.js";
+import type { DetailedTokenUsage } from "@aura/db/schema";
 
 // ── Tool I/O Persistence ─────────────────────────────────────────────────────
 // Accumulated during streaming and attached as invisible Slack message metadata
@@ -168,11 +169,7 @@ export interface LLMResponse {
   /** Whether the response was already posted to Slack via streaming */
   alreadyPosted: boolean;
   /** Token usage */
-  usage?: {
-    inputTokens: number;
-    outputTokens: number;
-    totalTokens: number;
-  };
+  usage?: DetailedTokenUsage;
   /** Tool calls executed during this response */
   toolCalls: ToolCallRecord[];
   /** Model ID used for this response */
@@ -1171,7 +1168,7 @@ export async function generateResponse(
     return {
       raw: finalText,
       alreadyPosted: true,
-      usage: { inputTokens, outputTokens, totalTokens },
+      usage: { inputTokens, outputTokens, totalTokens, inputTokenDetails: usage.inputTokenDetails, outputTokenDetails: usage.outputTokenDetails },
       toolCalls: toolCallRecords,
       modelId,
       stepsPromise: result.steps,
@@ -1280,6 +1277,8 @@ export async function generateResponse(
             inputTokens: retryInputTokens,
             outputTokens: retryOutputTokens,
             totalTokens: retryInputTokens + retryOutputTokens,
+            inputTokenDetails: retryUsage.inputTokenDetails,
+            outputTokenDetails: retryUsage.outputTokenDetails,
           },
           toolCalls: toolCallRecords,
           modelId,

--- a/apps/dashboard/src/app/conversations/[id]/conversation-detail.tsx
+++ b/apps/dashboard/src/app/conversations/[id]/conversation-detail.tsx
@@ -24,7 +24,18 @@ export function ConversationDetail({ data }: { data: ConversationData }) {
     inputTokens?: number;
     outputTokens?: number;
     totalTokens?: number;
+    inputTokenDetails?: {
+      noCacheTokens?: number;
+      cacheReadTokens?: number;
+      cacheWriteTokens?: number;
+    };
+    outputTokenDetails?: {
+      textTokens?: number;
+      reasoningTokens?: number;
+    };
   } | null;
+
+  const costUsd = (trace as any).costUsd as string | null;
 
   return (
     <>
@@ -57,7 +68,7 @@ export function ConversationDetail({ data }: { data: ConversationData }) {
         </div>
       </div>
 
-      <div className="grid gap-3 md:grid-cols-4">
+      <div className="grid gap-3 md:grid-cols-5">
         <Card>
           <CardHeader>
             <CardTitle>Timestamp</CardTitle>
@@ -94,13 +105,38 @@ export function ConversationDetail({ data }: { data: ConversationData }) {
         </Card>
         <Card>
           <CardHeader>
+            <CardTitle>Cost</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <span className="text-sm font-mono">
+              {costUsd ? `$${parseFloat(costUsd).toFixed(4)}` : "—"}
+            </span>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
             <CardTitle>Tokens</CardTitle>
           </CardHeader>
           <CardContent>
             {tokenUsage ? (
               <div className="text-sm space-y-0.5">
                 <div>In: {tokenUsage.inputTokens?.toLocaleString() ?? "—"}</div>
+                {tokenUsage.inputTokenDetails && (
+                  <div className="text-xs text-muted-foreground pl-2">
+                    {tokenUsage.inputTokenDetails.cacheReadTokens != null && (
+                      <span>cache read: {tokenUsage.inputTokenDetails.cacheReadTokens.toLocaleString()} </span>
+                    )}
+                    {tokenUsage.inputTokenDetails.cacheWriteTokens != null && (
+                      <span>write: {tokenUsage.inputTokenDetails.cacheWriteTokens.toLocaleString()}</span>
+                    )}
+                  </div>
+                )}
                 <div>Out: {tokenUsage.outputTokens?.toLocaleString() ?? "—"}</div>
+                {tokenUsage.outputTokenDetails?.reasoningTokens != null && tokenUsage.outputTokenDetails.reasoningTokens > 0 && (
+                  <div className="text-xs text-muted-foreground pl-2">
+                    reasoning: {tokenUsage.outputTokenDetails.reasoningTokens.toLocaleString()}
+                  </div>
+                )}
                 <div className="text-muted-foreground">Total: {tokenUsage.totalTokens?.toLocaleString() ?? "—"}</div>
               </div>
             ) : (

--- a/apps/dashboard/src/app/conversations/actions.ts
+++ b/apps/dashboard/src/app/conversations/actions.ts
@@ -98,6 +98,7 @@ export async function getConversations(
       messageCount: messageCounts[trace.id] ?? 0,
       sourceLabel,
       tokenUsage,
+      costUsd: trace.costUsd,
     };
   });
 

--- a/apps/dashboard/src/app/conversations/conversations-table.tsx
+++ b/apps/dashboard/src/app/conversations/conversations-table.tsx
@@ -21,6 +21,7 @@ interface ConversationRow {
     outputTokens?: number;
     totalTokens?: number;
   } | null;
+  costUsd: string | null;
   messageCount: number;
   createdAt: Date;
   channelId: string | null;
@@ -93,6 +94,7 @@ export function ConversationsTable({ conversations, total, page, pageSize }: Pro
             <TableHead>Source</TableHead>
             <TableHead>Source Label</TableHead>
             <TableHead>Model</TableHead>
+            <TableHead>Cost</TableHead>
             <TableHead>Tokens</TableHead>
             <TableHead>Messages</TableHead>
           </TableRow>
@@ -118,6 +120,9 @@ export function ConversationsTable({ conversations, total, page, pageSize }: Pro
               <TableCell className="text-sm text-muted-foreground font-mono">
                 {conv.modelId ?? "—"}
               </TableCell>
+              <TableCell className="text-sm text-muted-foreground font-mono">
+                {conv.costUsd ? `$${parseFloat(conv.costUsd).toFixed(4)}` : "—"}
+              </TableCell>
               <TableCell className="text-sm text-muted-foreground">
                 {conv.tokenUsage
                   ? `${(conv.tokenUsage.inputTokens ?? 0).toLocaleString()} / ${(conv.tokenUsage.outputTokens ?? 0).toLocaleString()}`
@@ -130,7 +135,7 @@ export function ConversationsTable({ conversations, total, page, pageSize }: Pro
           ))}
           {conversations.length === 0 && (
             <TableRow>
-              <TableCell colSpan={6} className="text-center text-muted-foreground py-8">
+              <TableCell colSpan={7} className="text-center text-muted-foreground py-8">
                 No conversations found
               </TableCell>
             </TableRow>

--- a/apps/dashboard/src/app/jobs/[id]/executions/[execId]/execution-detail.tsx
+++ b/apps/dashboard/src/app/jobs/[id]/executions/[execId]/execution-detail.tsx
@@ -14,6 +14,7 @@ interface ExecutionData {
   execution: JobExecution;
   conversation: ConversationMessageWithParts[];
   conversationTraceId?: string | null;
+  costUsd?: string | null;
 }
 
 export function ExecutionDetail({
@@ -23,7 +24,7 @@ export function ExecutionDetail({
   data: ExecutionData;
   jobId: string;
 }) {
-  const { execution, conversation, conversationTraceId } = data;
+  const { execution, conversation, conversationTraceId, costUsd } = data;
 
   const tokenUsage = execution.tokenUsage as {
     inputTokens?: number;
@@ -69,7 +70,7 @@ export function ExecutionDetail({
         </div>
       </div>
 
-      <div className="grid gap-3 md:grid-cols-4">
+      <div className="grid gap-3 md:grid-cols-5">
         <Card>
           <CardHeader>
             <CardTitle>Started</CardTitle>
@@ -85,6 +86,16 @@ export function ExecutionDetail({
           <CardContent>
             <span className="text-sm">
               {formatDate(execution.finishedAt)}
+            </span>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Cost</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <span className="text-sm font-mono">
+              {costUsd ? `$${parseFloat(costUsd).toFixed(4)}` : "—"}
             </span>
           </CardContent>
         </Card>

--- a/apps/dashboard/src/app/jobs/[id]/job-detail.tsx
+++ b/apps/dashboard/src/app/jobs/[id]/job-detail.tsx
@@ -10,9 +10,11 @@ import { ArrowLeft } from "lucide-react";
 import { formatDate } from "@/lib/utils";
 import type { Job, JobExecution } from "@schema";
 
+type ExecutionWithCost = JobExecution & { costUsd: string | null };
+
 interface JobData {
   job: Job;
-  executions: JobExecution[];
+  executions: ExecutionWithCost[];
 }
 
 export function JobDetail({ data }: { data: JobData }) {
@@ -76,6 +78,7 @@ export function JobDetail({ data }: { data: JobData }) {
                 <TableHead>Started</TableHead>
                 <TableHead>Finished</TableHead>
                 <TableHead>Status</TableHead>
+                <TableHead>Cost</TableHead>
                 <TableHead>Trigger</TableHead>
                 <TableHead>Error</TableHead>
               </TableRow>
@@ -101,6 +104,9 @@ export function JobDetail({ data }: { data: JobData }) {
                       {exec.status}
                     </Badge>
                   </TableCell>
+                  <TableCell className="text-sm font-mono text-muted-foreground">
+                    {exec.costUsd ? `$${parseFloat(exec.costUsd).toFixed(4)}` : "—"}
+                  </TableCell>
                   <TableCell className="text-sm">{exec.trigger}</TableCell>
                   <TableCell className="text-sm text-muted-foreground max-w-xs truncate">
                     {exec.error || "—"}
@@ -109,7 +115,7 @@ export function JobDetail({ data }: { data: JobData }) {
               ))}
               {executions.length === 0 && (
                 <TableRow>
-                  <TableCell colSpan={5} className="text-center text-muted-foreground py-8">
+                  <TableCell colSpan={6} className="text-center text-muted-foreground py-8">
                     No executions yet
                   </TableCell>
                 </TableRow>

--- a/apps/dashboard/src/app/jobs/actions.ts
+++ b/apps/dashboard/src/app/jobs/actions.ts
@@ -2,7 +2,7 @@
 
 import { db } from "@/lib/db";
 import { jobs, jobExecutions, conversationTraces } from "@schema";
-import { eq, desc, ilike, sql } from "drizzle-orm";
+import { eq, desc, ilike, sql, inArray } from "drizzle-orm";
 import { fetchConversationWithParts } from "@/lib/queries";
 import { revalidatePath } from "next/cache";
 
@@ -37,7 +37,30 @@ export async function getJob(id: string) {
     .orderBy(desc(jobExecutions.startedAt))
     .limit(50);
 
-  return { job, executions };
+  const execIds = executions.map((e) => e.id);
+  let execCosts: Record<string, string | null> = {};
+  if (execIds.length > 0) {
+    const costRows = await db
+      .select({
+        jobExecutionId: conversationTraces.jobExecutionId,
+        costUsd: conversationTraces.costUsd,
+      })
+      .from(conversationTraces)
+      .where(inArray(conversationTraces.jobExecutionId, execIds));
+
+    execCosts = Object.fromEntries(
+      costRows
+        .filter((r) => r.jobExecutionId != null)
+        .map((r) => [r.jobExecutionId!, r.costUsd]),
+    );
+  }
+
+  const executionsWithCost = executions.map((exec) => ({
+    ...exec,
+    costUsd: execCosts[exec.id] ?? null,
+  }));
+
+  return { job, executions: executionsWithCost };
 }
 
 export async function getExecution(execId: string) {
@@ -59,11 +82,11 @@ export async function getExecutionWithConversation(execId: string) {
     .where(eq(conversationTraces.jobExecutionId, execId))
     .limit(1);
 
-  if (!trace) return { execution: exec, conversation: [], conversationTraceId: null };
+  if (!trace) return { execution: exec, conversation: [], conversationTraceId: null, costUsd: null };
 
   const conversation = await fetchConversationWithParts(trace.id);
 
-  return { execution: exec, conversation, conversationTraceId: trace.id };
+  return { execution: exec, conversation, conversationTraceId: trace.id, costUsd: trace.costUsd };
 }
 
 export async function toggleJobEnabled(id: string, enabled: boolean) {

--- a/apps/dashboard/src/components/unified-timeline.tsx
+++ b/apps/dashboard/src/components/unified-timeline.tsx
@@ -219,6 +219,14 @@ function UserMessageBlock({ text }: { text: string }) {
 }
 
 function AssistantStepBlock({ msg, stepIndex }: { msg: ConversationMessageWithParts; stepIndex: number }) {
+  const stepTokenUsage = msg.tokenUsage as {
+    inputTokens?: number;
+    outputTokens?: number;
+    totalTokens?: number;
+    inputTokenDetails?: { cacheReadTokens?: number; cacheWriteTokens?: number };
+    outputTokenDetails?: { reasoningTokens?: number };
+  } | null;
+
   return (
     <div className="border rounded-md">
       <div className="flex items-center gap-2 px-3 py-2 bg-muted/30">
@@ -226,7 +234,20 @@ function AssistantStepBlock({ msg, stepIndex }: { msg: ConversationMessageWithPa
           Step {stepIndex}
         </Badge>
         <Badge variant="outline" className="text-[10px]">assistant</Badge>
-        <span className="text-xs text-muted-foreground ml-auto">
+        {msg.modelId && (
+          <span className="text-[10px] text-muted-foreground font-mono">
+            {msg.modelId}
+          </span>
+        )}
+        <span className="text-xs text-muted-foreground ml-auto flex items-center gap-2">
+          {stepTokenUsage && (
+            <span className="font-mono text-[10px]">
+              {(stepTokenUsage.inputTokens ?? 0).toLocaleString()} in / {(stepTokenUsage.outputTokens ?? 0).toLocaleString()} out
+              {stepTokenUsage.outputTokenDetails?.reasoningTokens
+                ? ` (${stepTokenUsage.outputTokenDetails.reasoningTokens.toLocaleString()} reasoning)`
+                : ""}
+            </span>
+          )}
           {formatDate(msg.createdAt)}
         </span>
       </div>

--- a/packages/db/drizzle/0041_per_conversation_cost_tracking.sql
+++ b/packages/db/drizzle/0041_per_conversation_cost_tracking.sql
@@ -1,0 +1,51 @@
+-- Per-conversation cost tracking (issue #719)
+-- Adds model_pricing table, cost_usd to conversation_traces,
+-- and model_id + token_usage to conversation_messages.
+
+CREATE TABLE IF NOT EXISTS "model_pricing" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "model_id" text NOT NULL,
+  "token_type" text NOT NULL,
+  "price_per_million" numeric NOT NULL,
+  "effective_from" date NOT NULL,
+  "effective_until" date,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "model_pricing_model_token_date_unique" UNIQUE("model_id","token_type","effective_from"),
+  CONSTRAINT "model_pricing_token_type_check" CHECK ("token_type" IN ('input', 'cache_read', 'cache_write', 'output', 'reasoning'))
+); --> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "model_pricing_model_id_idx" ON "model_pricing" USING btree ("model_id"); --> statement-breakpoint
+
+ALTER TABLE "conversation_traces" ADD COLUMN IF NOT EXISTS "cost_usd" numeric; --> statement-breakpoint
+
+ALTER TABLE "conversation_messages" ADD COLUMN IF NOT EXISTS "model_id" text; --> statement-breakpoint
+ALTER TABLE "conversation_messages" ADD COLUMN IF NOT EXISTS "token_usage" jsonb; --> statement-breakpoint
+
+-- Seed current Anthropic pricing (March 2026)
+-- Using gateway format: anthropic/model-name
+INSERT INTO "model_pricing" ("model_id", "token_type", "price_per_million", "effective_from") VALUES
+  -- Claude Opus 4.6
+  ('claude-opus-4-6', 'input', 15, '2025-01-01'),
+  ('claude-opus-4-6', 'cache_read', 1.50, '2025-01-01'),
+  ('claude-opus-4-6', 'cache_write', 18.75, '2025-01-01'),
+  ('claude-opus-4-6', 'output', 75, '2025-01-01'),
+  ('claude-opus-4-6', 'reasoning', 75, '2025-01-01'),
+  -- Claude Sonnet 4.6
+  ('claude-sonnet-4-6', 'input', 3, '2025-01-01'),
+  ('claude-sonnet-4-6', 'cache_read', 0.30, '2025-01-01'),
+  ('claude-sonnet-4-6', 'cache_write', 3.75, '2025-01-01'),
+  ('claude-sonnet-4-6', 'output', 15, '2025-01-01'),
+  ('claude-sonnet-4-6', 'reasoning', 15, '2025-01-01'),
+  -- Claude Haiku 3.5.6
+  ('claude-haiku-3-5-6', 'input', 0.80, '2025-01-01'),
+  ('claude-haiku-3-5-6', 'cache_read', 0.08, '2025-01-01'),
+  ('claude-haiku-3-5-6', 'cache_write', 1.00, '2025-01-01'),
+  ('claude-haiku-3-5-6', 'output', 4, '2025-01-01'),
+  ('claude-haiku-3-5-6', 'reasoning', 4, '2025-01-01'),
+  -- Also add with full date suffix variants (AI SDK may return these)
+  ('claude-sonnet-4-20250514', 'input', 3, '2025-01-01'),
+  ('claude-sonnet-4-20250514', 'cache_read', 0.30, '2025-01-01'),
+  ('claude-sonnet-4-20250514', 'cache_write', 3.75, '2025-01-01'),
+  ('claude-sonnet-4-20250514', 'output', 15, '2025-01-01'),
+  ('claude-sonnet-4-20250514', 'reasoning', 15, '2025-01-01')
+ON CONFLICT ("model_id", "token_type", "effective_from") DO NOTHING;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -337,6 +337,13 @@
       "when": 1773916800000,
       "tag": "0047_credential_description",
       "breakpoints": true
+    },
+    {
+      "idx": 48,
+      "version": "7",
+      "when": 1774003200000,
+      "tag": "0041_per_conversation_cost_tracking",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -17,6 +17,7 @@ import {
   check,
   primaryKey,
   smallint,
+  numeric,
 } from "drizzle-orm/pg-core";
 import { sql } from "drizzle-orm";
 
@@ -395,6 +396,52 @@ export const jobExecutions = pgTable(
   ],
 );
 
+// ── Token usage types ────────────────────────────────────────────────────────
+
+export interface DetailedTokenUsage {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  inputTokenDetails?: {
+    noCacheTokens?: number;
+    cacheReadTokens?: number;
+    cacheWriteTokens?: number;
+  };
+  outputTokenDetails?: {
+    textTokens?: number;
+    reasoningTokens?: number;
+  };
+}
+
+// ── Model Pricing ───────────────────────────────────────────────────────────
+
+export const modelPricing = pgTable(
+  "model_pricing",
+  {
+    id: uuid("id")
+      .primaryKey()
+      .default(sql`gen_random_uuid()`),
+    modelId: text("model_id").notNull(),
+    tokenType: text("token_type").notNull(),
+    pricePerMillion: numeric("price_per_million").notNull(),
+    effectiveFrom: date("effective_from", { mode: "date" }).notNull(),
+    effectiveUntil: date("effective_until", { mode: "date" }),
+    createdAt: timestamptz("created_at").notNull().defaultNow(),
+  },
+  (table) => [
+    unique("model_pricing_model_token_date_unique").on(
+      table.modelId,
+      table.tokenType,
+      table.effectiveFrom,
+    ),
+    index("model_pricing_model_id_idx").on(table.modelId),
+    check(
+      "model_pricing_token_type_check",
+      sql`${table.tokenType} IN ('input', 'cache_read', 'cache_write', 'output', 'reasoning')`,
+    ),
+  ],
+);
+
 // ── Conversation Traces + Messages + Parts (unified conversation persistence) ─
 
 export const conversationTraces = pgTable(
@@ -409,7 +456,8 @@ export const conversationTraces = pgTable(
     threadTs: text("thread_ts"),
     userId: text("user_id"),
     modelId: text("model_id"),
-    tokenUsage: jsonb("token_usage").$type<{ inputTokens: number; outputTokens: number; totalTokens: number }>(),
+    tokenUsage: jsonb("token_usage").$type<DetailedTokenUsage>(),
+    costUsd: numeric("cost_usd"),
     createdAt: timestamptz("created_at").notNull().defaultNow(),
   },
   (table) => [
@@ -435,6 +483,8 @@ export const conversationMessages = pgTable(
     role: text("role").notNull(),
     content: text("content"),
     orderIndex: integer("order_index").notNull(),
+    modelId: text("model_id"),
+    tokenUsage: jsonb("token_usage").$type<DetailedTokenUsage>(),
     createdAt: timestamptz("created_at").notNull().defaultNow(),
   },
   (table) => [
@@ -933,3 +983,5 @@ export type ConversationMessage = typeof conversationMessages.$inferSelect;
 export type NewConversationMessage = typeof conversationMessages.$inferInsert;
 export type ConversationPart = typeof conversationParts.$inferSelect;
 export type NewConversationPart = typeof conversationParts.$inferInsert;
+export type ModelPricing = typeof modelPricing.$inferSelect;
+export type NewModelPricing = typeof modelPricing.$inferInsert;


### PR DESCRIPTION
## Upstream sync: AuraHQ-ai/aura -> wieseljonas/nova

### 7 new upstream commits

- `810d2f8` fix: update persistConversationTrace usage param type to DetailedTokenUsage
- `7f488c3` Fix: derive noCacheTokens from inputTokens when missing, replace mapRawStepsToConversationSteps with buildConversationSteps
- `a003536` Remove redundant DetailedTokenUsage copy in pipeline
- `1a23f97` Fix SQL IN clause with array and cost calculation fallback
- `a62651c` Deduplicate step-usage and conversation-step building logic
- `92cbcea` Fix: pass detailed token usage in interactive pipeline and remove dead code
- `a6ff6c9` feat: per-conversation cost tracking with full token breakdown and pricing table (#719)

### Key changes
- **Per-conversation cost tracking**: new pricing table, token breakdown stored per conversation trace, dashboard UI updates
- **buildConversationSteps refactor**: extracted shared logic for building conversation steps from raw AI SDK steps (deduplicated between interactive pipeline and job execution)
- **Cost calculator**: new `cost-calculator.ts` module with step-level usage tracking

### Conflicts resolved (2 files)
1. **`apps/api/src/cron/execute-job.ts`** -- upstream replaced inline step-mapping with `buildConversationSteps()`. Took upstream's version (our code was the same inline logic).
2. **`packages/db/drizzle/meta/_journal.json`** -- upstream added migration idx 41 (`per_conversation_cost_tracking`), but we already have Nova-specific migrations 41-47. Kept ours, added upstream's entry as idx 48.

### Files changed (15)
- 2 pipeline files (execute-job.ts, index.ts) -- step building refactor
- 1 new module (cost-calculator.ts)
- 1 new migration (0041_per_conversation_cost_tracking.sql, journaled as idx 48)
- Schema additions for cost tracking columns
- Dashboard UI updates for cost display

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new DB tables/columns and persists step-level model/token usage to compute and store per-conversation costs; mistakes could impact analytics accuracy and dashboard displays but core execution flow remains largely unchanged.
> 
> **Overview**
> Adds **per-conversation cost tracking** by introducing `model_pricing` and storing `costUsd` on `conversation_traces`, plus per-step `modelId` and detailed `tokenUsage` on `conversation_messages`.
> 
> Job execution and interactive pipeline paths now persist **detailed token breakdowns** (cache read/write, reasoning tokens) and compute total USD cost via a new `cost-calculator.ts` that looks up pricing by model/effective date and tolerates missing pricing.
> 
> Dashboard updates show **cost** alongside token counts in conversation lists/details and job execution views, and the unified timeline now displays per-step model + token usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36444fcb56fee1717991e5cadce2b6cd657c68cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->