### PR TITLE
fix: bump migration 0049 timestamp to avoid drizzle skip

### DIFF
--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -348,7 +348,7 @@
     {
       "idx": 49,
       "version": "7",
-      "when": 1774003200000,
+      "when": 1774003200001,
       "tag": "0049_unified_approval_system",
       "breakpoints": true
     },


### PR DESCRIPTION
Migrations 0048 and 0049 both had when=1774003200000. Drizzle strict < comparison skipped 0049 on deploy 2. Bump to 1774003200001.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: metadata-only change that affects migration ordering/execution, with no schema or runtime logic changes.
> 
> **Overview**
> **Fixes a migration ordering issue in Drizzle.** Updates `packages/db/drizzle/meta/_journal.json` so `0049_unified_approval_system` has a slightly later `when` value than `0048_per_conversation_cost_tracking`, preventing Drizzle from skipping `0049` due to identical timestamps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit abc4f8c5238b97cbfed5c6cc2e9bb122c97d8d56. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->