### PR TITLE
fix: bump migration 0049 timestamp above 0050

### DIFF
--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -348,7 +348,7 @@
     {
       "idx": 49,
       "version": "7",
-      "when": 1774003200001,
+      "when": 1774089600001,
       "tag": "0049_unified_approval_system",
       "breakpoints": true
     },


### PR DESCRIPTION
Migration 0049 was skipped because its when (1774003200001) was still below the already-applied 0050 (1774089600000). Drizzle migrator uses strict < against the last applied migration, so 0049 was permanently buried.

Bumps 0049 when to 1774089600001 (above 0050). On next deploy, drizzle picks it up and creates approvals/approval_items tables + adds missing columns to approval_policies.

0049 and 0050 are independent (creates new tables vs drops legacy), so out-of-order execution is safe.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes migration ordering metadata, which affects what schema changes run on the next deploy and could impact production databases if assumptions about prior state are wrong.
> 
> **Overview**
> Fixes Drizzle migration ordering by bumping the `when` timestamp for `0049_unified_approval_system` in `packages/db/drizzle/meta/_journal.json` so it sorts after the already-applied `0050_remove_legacy_approval_system`.
> 
> This prevents `0049` from being skipped and ensures its schema changes are picked up on the next migration run.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1164f401fda08e29366e8dee7ada99037ee69578. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->