### PR TITLE
fix: reconcile migration journal + add missing columns

### DIFF
--- a/packages/db/drizzle/0051_migration_reconciliation.sql
+++ b/packages/db/drizzle/0051_migration_reconciliation.sql
@@ -1,0 +1,10 @@
+-- Migration reconciliation: fix schema drift from skipped/hand-written migrations
+-- 
+-- Two columns exist in schema.ts but are missing from the production DB:
+-- 1. messages.token_usage (jsonb) - from migration 0035, which was skipped due to
+--    duplicate journal timestamps causing drizzle's strict < comparison to fail
+-- 2. approvals.approver_ids (text[]) - omitted from hand-written migration 0049
+--    (the SQL only created approved_by but schema.ts also defines approver_ids)
+
+ALTER TABLE "messages" ADD COLUMN IF NOT EXISTS "token_usage" jsonb;--> statement-breakpoint
+ALTER TABLE "approvals" ADD COLUMN IF NOT EXISTS "approver_ids" text[];

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -82,28 +82,28 @@
     {
       "idx": 11,
       "version": "7",
-      "when": 1771518167844,
+      "when": 1771600000001,
       "tag": "0011_moaning_chimera",
       "breakpoints": true
     },
     {
       "idx": 12,
       "version": "7",
-      "when": 1771526241905,
+      "when": 1771600000002,
       "tag": "0012_curvy_tombstone",
       "breakpoints": true
     },
     {
       "idx": 13,
       "version": "7",
-      "when": 1771561682063,
+      "when": 1771600000003,
       "tag": "0013_ambiguous_sunspot",
       "breakpoints": true
     },
     {
       "idx": 14,
       "version": "7",
-      "when": 1771593578962,
+      "when": 1771600000004,
       "tag": "0014_sudden_scarecrow",
       "breakpoints": true
     },
@@ -124,7 +124,7 @@
     {
       "idx": 17,
       "version": "7",
-      "when": 1771757715594,
+      "when": 1771804800001,
       "tag": "0017_amused_kree",
       "breakpoints": true
     },
@@ -180,7 +180,7 @@
     {
       "idx": 25,
       "version": "7",
-      "when": 1772600000000,
+      "when": 1772793600001,
       "tag": "0025_feedback_table",
       "breakpoints": true
     },
@@ -194,7 +194,7 @@
     {
       "idx": 27,
       "version": "7",
-      "when": 1772880000000,
+      "when": 1772880000001,
       "tag": "0027_api_credentials",
       "breakpoints": true
     },
@@ -222,7 +222,7 @@
     {
       "idx": 31,
       "version": "7",
-      "when": 1772880000000,
+      "when": 1773139200001,
       "tag": "0031_hybrid_memory_search",
       "breakpoints": true
     },
@@ -292,49 +292,49 @@
     {
       "idx": 41,
       "version": "7",
-      "when": 1773916800000,
+      "when": 1773916800001,
       "tag": "0041_credential_auth_scheme",
       "breakpoints": true
     },
     {
       "idx": 42,
       "version": "7",
-      "when": 1773916800000,
+      "when": 1773916800002,
       "tag": "0042_google_service_account_auth_scheme",
       "breakpoints": true
     },
     {
       "idx": 43,
       "version": "7",
-      "when": 1773916800000,
+      "when": 1773916800003,
       "tag": "0043_add_hitl_resumption_fields",
       "breakpoints": true
     },
     {
       "idx": 44,
       "version": "7",
-      "when": 1773916800000,
+      "when": 1773916800004,
       "tag": "0044_credential_allowed_methods",
       "breakpoints": true
     },
     {
       "idx": 45,
       "version": "7",
-      "when": 1773916800000,
+      "when": 1773916800005,
       "tag": "0045_credential_display_name",
       "breakpoints": true
     },
     {
       "idx": 46,
       "version": "7",
-      "when": 1773916800000,
+      "when": 1773916800006,
       "tag": "0046_approval_summary_credential_description",
       "breakpoints": true
     },
     {
       "idx": 47,
       "version": "7",
-      "when": 1773916800000,
+      "when": 1773916800007,
       "tag": "0047_credential_description",
       "breakpoints": true
     },
@@ -355,8 +355,15 @@
     {
       "idx": 50,
       "version": "7",
-      "when": 1774089600000,
+      "when": 1774089600002,
       "tag": "0050_remove_legacy_approval_system",
+      "breakpoints": true
+    },
+    {
+      "idx": 51,
+      "version": "7",
+      "when": 1774089600003,
+      "tag": "0051_migration_reconciliation",
       "breakpoints": true
     }
   ]


### PR DESCRIPTION
## Problem

Every Nova migration (0041-0050) was hand-written by Cursor Agent with fabricated round epoch-day timestamps. This caused:

1. **13 duplicate `when` timestamps** in the journal -- drizzle's migrator uses strict `<` against the last applied migration, so same-timestamp migrations in different deploys get permanently skipped
2. **4 non-monotonic entries** -- later indices with earlier timestamps
3. **2 missing columns** in production:
   - `messages.token_usage` (jsonb) -- from migration 0035, skipped when 0036 deployed first with a higher timestamp
   - `approvals.approver_ids` (text[]) -- omitted from hand-written migration 0049

## Fix

- **0051_migration_reconciliation.sql**: adds the two missing columns (idempotent with IF NOT EXISTS)
- **_journal.json**: all timestamps now unique and strictly monotonically increasing
- Migration 0050 will re-run (safe -- all IF EXISTS/IF NOT EXISTS statements)

## What will happen on deploy

Drizzle migrator sees `lastDbMigration.created_at = 1774089600001`.
- 0050 (`when: 1774089600002`): re-runs (idempotent DROP IF EXISTS / ALTER DROP IF EXISTS)
- 0051 (`when: 1774089600003`): runs, adds missing columns

## Prevention

Migration discipline is now codified in Nova's self-directive: never hand-write migrations, always use `pnpm --filter @aura/db db:generate`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts drizzle migration ordering metadata and introduces a new reconciliation migration; incorrect ordering or non-idempotent prior migrations could cause unexpected re-runs during deploy.
> 
> **Overview**
> Adds `0051_migration_reconciliation.sql`, which **idempotently** backfills two missing columns: `messages.token_usage` (jsonb) and `approvals.approver_ids` (text[]).
> 
> Updates `drizzle/meta/_journal.json` to make `when` timestamps **unique and strictly monotonically increasing**, and appends the new `0051_migration_reconciliation` entry so previously-skipped/duplicate-timestamp migrations are no longer skipped (with `0050` now ordered to potentially re-run).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5caab4708ec424fbef2998e1476b7e997f318a07. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->