### PR TITLE
fix: handle plain-string basic auth credentials

### DIFF
--- a/apps/api/src/tools/http-request.ts
+++ b/apps/api/src/tools/http-request.ts
@@ -117,10 +117,8 @@ export function createHttpRequestTool(context?: ScheduleContext) {
                 try {
                   basicParsed = JSON.parse(credResult.value);
                 } catch {
-                  return {
-                    ok: false as const,
-                    error: "basic credential value must be JSON {username, password}",
-                  };
+                  // Plain string value: treat as username with empty password (e.g. Close CRM API key)
+                  basicParsed = { username: credResult.value, password: "" };
                 }
                 const encoded = Buffer.from(
                   `${basicParsed.username}:${basicParsed.password ?? ""}`


### PR DESCRIPTION
When auth_scheme is basic but the credential value is a plain string (not JSON {username, password}), fall back to treating it as username with empty password. This is how Close CRM and similar APIs work -- the API key is the username, password is empty.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `basic` credentials are parsed and encoded for outbound requests, which could affect authentication behavior for integrations using this tool. The change is small and scoped to `http_request` credential injection logic.
> 
> **Overview**
> **Basic-auth credentials in `http_request` are now more permissive.** When a stored credential with `auth_scheme: basic` contains a plain string instead of JSON `{username, password}`, the tool no longer errors and instead treats the string as the username with an empty password before building the `Authorization: Basic ...` header.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7e7af554f2ee6394cc97ff21c3d76ae8ff7f9f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->