### PR TITLE
fix: post approval cards in the originating thread

### DIFF
--- a/apps/api/src/lib/batch-executor.ts
+++ b/apps/api/src/lib/batch-executor.ts
@@ -21,6 +21,7 @@ export interface CreateProposalArgs {
   items: ProposalItem[];
   requestedBy: string;
   requestedInChannel?: string;
+  requestedInThread?: string;
   slackClient?: WebClient;
 }
 
@@ -47,7 +48,7 @@ export async function createProposal(args: CreateProposalArgs): Promise<{
   approvalId?: string;
   error?: string;
 }> {
-  const { title, description, credentialName, items, requestedBy, requestedInChannel, slackClient: injectedSlackClient } = args;
+  const { title, description, credentialName, items, requestedBy, requestedInChannel, requestedInThread, slackClient: injectedSlackClient } = args;
 
   if (items.length === 0) {
     return { ok: false, error: "No items to approve" };
@@ -177,6 +178,7 @@ export async function createProposal(args: CreateProposalArgs): Promise<{
     }
 
     const resp = await slackClient.chat.postMessage({
+      ...(requestedInThread && { thread_ts: requestedInThread }),
       channel: targetChannel,
       text: `🔒 Approval required: ${title} — ${approverMentions}`,
       attachments: [

--- a/apps/api/src/lib/tool.ts
+++ b/apps/api/src/lib/tool.ts
@@ -154,6 +154,7 @@ export function defineTool<TInput, TOutput>(config: {
             }],
             requestedBy: ctx.triggeredBy,
             requestedInChannel: ctx.channelId,
+            requestedInThread: ctx.threadTs,
           });
 
           if (!result.ok) {

--- a/apps/api/src/tools/approvals.ts
+++ b/apps/api/src/tools/approvals.ts
@@ -63,6 +63,7 @@ Returns a proposal_id that tracks the batch through approval and execution.`,
       items: input.items as any,
       requestedBy: ctx.triggeredBy,
       requestedInChannel: ctx.channelId,
+      requestedInThread: ctx.threadTs,
     });
 
     if (result.ok) {


### PR DESCRIPTION
The approval card was posting as a new top-level message instead of in the thread where the request originated.

**Root cause:** `createProposal` in `batch-executor.ts` calls `chat.postMessage` without `thread_ts`.

**Fix:** Pass `ctx.threadTs` through as `requestedInThread` and spread it into the `postMessage` call. Fixed in both call sites:
- `tool.ts` (single `http_request` write)
- `approvals.ts` (`propose_batch`)

5 lines changed across 3 files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes Slack message posting metadata by threading approval cards using an existing `threadTs` value, without altering approval persistence or execution logic.
> 
> **Overview**
> **Approval request cards now post as replies in the originating Slack thread** instead of always creating a new top-level message.
> 
> This threads both single `http_request` approval prompts and `propose_batch` proposals by passing `ctx.threadTs` through to `createProposal` and setting `thread_ts` in `chat.postMessage` when available.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02c36c8366c7b727af82258370c5d3d053399c77. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->