### PR TITLE
fix: strip query params before regex pattern matching in proposal summaries

### DIFF
--- a/apps/api/src/lib/proposal-summary.ts
+++ b/apps/api/src/lib/proposal-summary.ts
@@ -173,12 +173,13 @@ export function generateProposalSummary(input: ProposalSummaryInput): ProposalSu
   const { credentialName, method, url, body, itemCount = 1 } = input;
   const methodUpper = method.toUpperCase();
 
-  // Try known patterns
+  // Try known patterns — strip query params before matching
+  const urlWithoutParams = url.split("?")[0];
   if (credentialName) {
     for (const pattern of ALL_PATTERNS) {
       if (pattern.credential !== credentialName) continue;
       if (pattern.methods && !pattern.methods.includes(methodUpper)) continue;
-      const match = url.match(pattern.urlMatch);
+      const match = urlWithoutParams.match(pattern.urlMatch);
       if (match) {
         return {
           title: pattern.title(match, methodUpper, body, itemCount),


### PR DESCRIPTION
Bugbot flagged this as Bug #3 on PR #81 (Medium severity).

**Problem:** `generateProposalSummary` runs regex patterns against the raw URL including query parameters. For $-anchored patterns with `([^/]+)` capture groups, query strings get captured as part of the resource ID -- e.g. `lead_abc?_fields=name` instead of `lead_abc`.

**Fix:** Strip query params with `url.split('?')[0]` before pattern matching. Consistent with `batch-executor.ts` which already does this.

One-line change, no new deps.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, localized change to proposal summary generation that only affects how URLs are regex-matched for known patterns.
> 
> **Overview**
> Updates `generateProposalSummary` to **strip query parameters** (using `url.split("?")[0]`) before applying known `urlMatch` regex patterns, preventing query strings from being captured as part of resource IDs in generated proposal titles/descriptions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c82d2ff71bd1075cbd6e745fbf0cce4e190f6cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->