### PR TITLE
feat: wire reason param from http_request to proposal summary

### DIFF
--- a/apps/api/src/lib/tool.ts
+++ b/apps/api/src/lib/tool.ts
@@ -149,6 +149,7 @@ export function defineTool<TInput, TOutput>(config: {
             url,
             body: httpInput.body,
             itemCount: 1,
+            reason: httpInput.reason,
           });
           const result = await createProposal({
             title: summary.title,

--- a/apps/api/src/tools/http-request.ts
+++ b/apps/api/src/tools/http-request.ts
@@ -63,6 +63,14 @@ export function createHttpRequestTool(context?: ScheduleContext) {
           .number()
           .default(30_000)
           .describe("Request timeout in milliseconds (default 30s)"),
+        reason: z
+          .string()
+          .optional()
+          .describe(
+            "Brief context explaining WHY this request is being made. " +
+            "Shown to the human reviewer on the approval card. " +
+            "E.g. 'Creating a test lead for HITL testing as requested by Jonas'"
+          ),
       }),
       execute: async (input) => {
         try {


### PR DESCRIPTION
Cherry-picked from PR #88 onto a clean base (resolving conflicts).

Adds `reason` field to `http_request` tool so the calling LLM can explain *why* it's making the request. This gets passed through to `generateProposalSummary` and included in the approval card.

Two files, 9 lines:
- `http-request.ts` -- new optional `reason` field in Zod schema
- `tool.ts` -- passes `httpInput.reason` to `generateProposalSummary`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional `reason` field to `http_request` inputs and threads it into the approval-card proposal summary without changing request execution or security controls.
> 
> **Overview**
> Adds an optional `reason` parameter to the `http_request` tool so callers can provide brief context for why an external API call is being made.
> 
> When an `http_request` requires human approval, this `reason` is now forwarded into `generateProposalSummary` so the approval card includes that context for reviewers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b9cd71582e372370fd79400950c5ca7669aa7a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->