### PR TITLE
feat: improved proposal summary with generateObject, few-shot, credential labels

### DIFF
--- a/apps/api/src/lib/proposal-summary.ts
+++ b/apps/api/src/lib/proposal-summary.ts
@@ -1,10 +1,11 @@
 /**
  * Generate human-readable proposal summaries for approval cards.
- * Uses the fast LLM model (Haiku) to produce compelling, context-rich summaries
- * from the full request details (method, URL, body, credential).
+ * Uses the fast LLM model (Haiku) with structured output (generateObject + Zod)
+ * to produce compelling, context-rich summaries from the full request details.
  */
 
-import { generateText } from "ai";
+import { generateObject } from "ai";
+import { z } from "zod";
 import { fastModel } from "./ai.js";
 
 interface ProposalSummaryInput {
@@ -13,6 +14,8 @@ interface ProposalSummaryInput {
   url: string;
   body?: unknown;
   itemCount?: number;
+  /** Optional caller-provided context explaining why this request is being made */
+  reason?: string;
 }
 
 interface ProposalSummary {
@@ -20,11 +23,37 @@ interface ProposalSummary {
   description: string;
 }
 
+// ── Credential → human-readable service name ────────────────────────────────
+
+const CREDENTIAL_LABELS: Record<string, string> = {
+  close_fr: "Close CRM (FR)",
+  close_us: "Close CRM (US)",
+  exa_websearch: "Exa Search",
+  e2b: "E2B Sandbox",
+};
+
+function getServiceName(credentialName?: string): string {
+  if (!credentialName) return "unknown API";
+  return CREDENTIAL_LABELS[credentialName] ?? credentialName;
+}
+
+// ── Structured output schema ────────────────────────────────────────────────
+
+const summarySchema = z.object({
+  title: z
+    .string()
+    .describe("Short action-oriented title (max 80 chars). Include the key entity name/identifier."),
+  description: z
+    .string()
+    .describe("Detailed summary of ALL inputs. Use Slack mrkdwn formatting: *bold* for field names, bullet points with •. List every meaningful field being set with its actual value."),
+});
+
 // ── Public API ───────────────────────────────────────────────────────────────
 
 export async function generateProposalSummary(input: ProposalSummaryInput): Promise<ProposalSummary> {
-  const { credentialName, method, url, body: rawBody, itemCount = 1 } = input;
+  const { credentialName, method, url, body: rawBody, itemCount = 1, reason } = input;
   const methodUpper = method.toUpperCase();
+  const serviceName = getServiceName(credentialName);
 
   // Parse string bodies — callers sometimes pass JSON as a string
   let body: unknown = rawBody;
@@ -37,55 +66,70 @@ export async function generateProposalSummary(input: ProposalSummaryInput): Prom
   }
 
   const bodyStr = body ? (typeof body === "string" ? body : JSON.stringify(body, null, 2)) : null;
+  const bodyPreview = bodyStr && bodyStr.length > 3000 ? bodyStr.slice(0, 3000) + "\n...(truncated)" : bodyStr;
 
-  // Truncate very large bodies to avoid blowing up the prompt
-  const bodyPreview = bodyStr && bodyStr.length > 2000 ? bodyStr.slice(0, 2000) + "\n...(truncated)" : bodyStr;
+  // Determine risk level for framing
+  const isDestructive = methodUpper === "DELETE";
+  const isBulk = itemCount > 1;
+  const riskNote = isDestructive
+    ? "⚠️ This is a DELETE request — flag it as destructive and potentially irreversible."
+    : isBulk
+      ? `⚠️ This is a batch operation affecting ${itemCount} items — emphasize the scope.`
+      : "";
 
-  const prompt = `You are generating a summary for an API approval card. A human reviewer needs to decide whether to approve or reject this action. Be specific and thorough -- the reviewer should understand exactly what will happen without needing to inspect the raw request.
+  const prompt = `You summarize API requests for a Slack approval card. The reviewer is a busy technical founder who needs to approve or reject in seconds.
 
-Request details:
-- Method: ${methodUpper}
-- URL: ${url}
-- Credential/API: ${credentialName ?? "unknown"}
-${bodyPreview ? `- Request body:\n\`\`\`json\n${bodyPreview}\n\`\`\`` : "- No request body"}
-${itemCount > 1 ? `- Batch size: ${itemCount} items` : ""}
+Your job: make it instantly clear *what* will happen, *to what*, and *with what data*. The reviewer should never need to click "Review items" or inspect raw JSON.
 
-Respond with exactly two sections:
-TITLE: A short (max 80 chars) action-oriented title. Include the key entity name. Examples: "Create lead 'Acme Corp' in Close CRM", "Delete contact john@example.com"
-DESCRIPTION: A detailed summary of ALL inputs -- not just the main entity. List every meaningful field being set: custom fields, tags, status, contacts, emails, addresses, assigned users, amounts, dates, etc. Use bullet points if there are 3+ fields. The reviewer should be able to approve confidently without clicking "Review items". Do NOT just repeat the title. Be specific with actual values from the body.`;
+Rules:
+- Translate API/technical field names to plain English (e.g. "custom.cf_xyz" → describe the value, "contacts[0].emails" → "Contact email")
+- Use Slack mrkdwn: *bold* for field labels, • for bullet points. NOT Markdown (**bold** is wrong).
+- For creates: name the entity being created + list every field being set with actual values
+- For updates/patches: say what's changing with actual values
+- For deletes: say exactly what's being removed
+- Never repeat the title in the description
+- Be specific with real values from the body — no generic "various fields will be set"
+${riskNote}
+
+Service: ${serviceName}
+Method: ${methodUpper}
+URL: ${url}
+${reason ? `Reason: ${reason}` : ""}
+${bodyPreview ? `Body:\n\`\`\`\n${bodyPreview}\n\`\`\`` : "No body"}
+${itemCount > 1 ? `Batch size: ${itemCount} items` : ""}
+
+Example input:
+POST https://api.close.com/api/v1/lead/
+Body: {"name":"Acme Corp","description":"Enterprise prospect","contacts":[{"name":"Jane Doe","emails":[{"email":"jane@acme.com"}]}],"custom.cf_industry":"SaaS","custom.cf_deal_size":"50000"}
+
+Example output:
+title: Create lead "Acme Corp" in Close CRM
+description: • *Lead name:* Acme Corp
+• *Description:* Enterprise prospect
+• *Contact:* Jane Doe (jane@acme.com)
+• *Industry:* SaaS
+• *Deal size:* 50,000
+
+Now summarize the request above.`;
 
   try {
-    const { text } = await generateText({
+    const { object } = await generateObject({
       model: fastModel,
+      schema: summarySchema,
       prompt,
-      maxTokens: 500,
       temperature: 0,
     });
 
-    const titleMatch = text.match(/TITLE:\s*(.+)/);
-    const descMatch = text.match(/DESCRIPTION:\s*([\s\S]+)/);
-
-    if (titleMatch && descMatch) {
-      return {
-        title: titleMatch[1].trim().slice(0, 120),
-        description: descMatch[1].trim(),
-      };
-    }
-
-    // Partial parse — use what we got
-    if (titleMatch) {
-      return {
-        title: titleMatch[1].trim().slice(0, 120),
-        description: formatBodyPreview(body),
-      };
-    }
+    return {
+      title: object.title.slice(0, 120),
+      description: object.description,
+    };
   } catch (err) {
-    // LLM call failed — fall back to static summary
     console.warn("generateProposalSummary: LLM call failed, using fallback", err);
   }
 
-  // Fallback: static summary (same as before but simpler)
-  return staticFallback(methodUpper, url, body, credentialName, itemCount);
+  // Fallback: static summary
+  return staticFallback(methodUpper, url, body, serviceName, itemCount);
 }
 
 // ── Fallback (no LLM) ───────────────────────────────────────────────────────
@@ -94,7 +138,7 @@ function staticFallback(
   method: string,
   url: string,
   body: unknown,
-  credentialName?: string,
+  serviceName: string,
   itemCount: number = 1,
 ): ProposalSummary {
   let urlPath: string;
@@ -104,12 +148,11 @@ function staticFallback(
     urlPath = url.split("?")[0] || url || "/unknown";
   }
   const shortUrl = urlPath.length > 60 ? urlPath.slice(0, 57) + "..." : urlPath;
-  const credLabel = credentialName ? ` via ${credentialName}` : "";
 
   return {
     title: itemCount > 1
-      ? `${method} ${itemCount} requests to ${shortUrl}${credLabel}`
-      : `${method} ${shortUrl}${credLabel}`,
+      ? `${method} ${itemCount} requests to ${shortUrl} via ${serviceName}`
+      : `${method} ${shortUrl} via ${serviceName}`,
     description: formatBodyPreview(body),
   };
 }


### PR DESCRIPTION
Implements the key improvements from #85:

## Changes
- **`generateObject` + Zod** replaces `generateText` + regex parsing -- structured output, no more parsing bugs
- **Few-shot example** in the prompt showing exact expected format (field-by-field bullet list with actual values)
- **Credential-to-service mapping** -- `close_fr` renders as "Close CRM (FR)" not raw credential name
- **Risk framing** -- DELETEs flagged as destructive, bulk ops emphasize scope
- **Slack mrkdwn enforced** -- prompt explicitly says `*bold*` not `**bold**`
- **`reason` param** -- optional caller intent context (not yet wired from tool.ts, that's next)
- **Body preview bumped** to 3000 chars for richer context

## What's NOT in this PR (future work from #85)
- Wiring `reason` param from the calling LLM
- Previous state fetching for update diffs  
- Custom field label resolution from target APIs

Closes #85

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the LLM summarization pipeline for approval cards (prompting + output parsing), so formatting or content regressions could impact what reviewers see when approving actions. Fallback behavior is still present, but summary quality now depends on schema adherence and the updated prompt.
> 
> **Overview**
> Approval-card proposal summaries are switched from `generateText` + regex parsing to `generateObject` with a Zod schema, returning structured `title`/`description` output.
> 
> The prompt is revamped to enforce Slack mrkdwn formatting, include a few-shot example, accept an optional `reason` field, expand body preview truncation to ~3000 chars, and add framing for DELETE and bulk operations. Credential names are mapped to human-friendly service labels and used in both the prompt and the static fallback title.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 160c87fc2e0150e6123821544fac3b5b59e03e3e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->