### PR TITLE
feat: wire reason param from http_request to approval card summary

### DIFF
--- a/apps/api/src/lib/tool.ts
+++ b/apps/api/src/lib/tool.ts
@@ -149,6 +149,7 @@ export function defineTool<TInput, TOutput>(config: {
             url,
             body: httpInput.body,
             itemCount: 1,
+            reason: httpInput.reason,
           });
           const result = await createProposal({
             title: summary.title,

--- a/apps/api/src/tools/http-request.ts
+++ b/apps/api/src/tools/http-request.ts
@@ -63,6 +63,14 @@ export function createHttpRequestTool(context?: ScheduleContext) {
           .number()
           .default(30_000)
           .describe("Request timeout in milliseconds (default 30s)"),
+        reason: z
+          .string()
+          .optional()
+          .describe(
+            "Brief context explaining WHY this request is being made. " +
+            "Shown to the human reviewer on the approval card. " +
+            "E.g. 'Creating a test lead for HITL testing as requested by Jonas'"
+          ),
       }),
       execute: async (input) => {
         try {


### PR DESCRIPTION
Adds an optional `reason` field to the `http_request` tool schema. The calling LLM explains *why* a request is being made, and this flows through to the approval card summary.

**Changes:**
- `http-request.ts`: new `reason` Zod field with descriptive help text
- `tool.ts`: passes `httpInput.reason` to `generateProposalSummary`

`proposal-summary.ts` already accepts and uses `reason` in the prompt (from PR #87), so this just completes the wiring.

**Result:** Approval cards now show intent like "Creating a test lead for HITL testing as requested by Jonas" instead of the LLM having to guess from the raw body alone.

Closes the "caller intent" item from #85.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional descriptive field and wires it into approval-card summarization without changing request execution or governance decisions.
> 
> **Overview**
> Approval cards for `http_request` can now include caller intent. This adds an optional `reason` field to the `http_request` tool input schema and passes it through the approval gating path in `defineTool()` to `generateProposalSummary`, so human reviewers see the provided context on the proposal card.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4667c7f4bfff4792a95aa0ffaaec2bf0209140a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->