### PR TITLE
improve: prettier recipe completion/failure Slack messages

### DIFF
--- a/apps/api/src/cron/run-recipe.ts
+++ b/apps/api/src/cron/run-recipe.ts
@@ -399,7 +399,7 @@ async function markRecipeSucceeded(
     await safePostMessage(slackClient, {
       channel: job.channelId,
       thread_ts: job.threadTs || undefined,
-      text: `Recipe "${job.name}" completed. ${firstLine}`,
+      text: `:white_check_mark: *${job.name}* completed\n>${firstLine}`,
     });
   }
 }
@@ -525,7 +525,7 @@ async function markRecipeFailed(
       if (dmResult.channel?.id) {
         await safePostMessage(slackClient, {
           channel: dmResult.channel.id,
-          text: `Recipe "${job.name}" failed after ${MAX_RETRIES} retries.\n\nError: ${errorMessage}`,
+          text: `:x: *${job.name}* failed after ${MAX_RETRIES} retries\n\n\`\`\`${errorMessage}\`\`\``,
         });
       }
     }


### PR DESCRIPTION
**Before:**
`Recipe "close-leads-sync" completed. === Close Leads Sync ===`

**After:**
:white_check_mark: **close-leads-sync** completed
> === Close Leads Sync ===

**Failure before:**
`Recipe "close-leads-sync" failed after 3 retries. Error: timeout...`

**Failure after:**
:x: **close-leads-sync** failed after 3 retries
```timeout...```

Two-line diff. Makes the channel notifications less noisy and easier to scan.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes Slack message formatting for recipe success/failure notifications, with no changes to execution, retry, or persistence logic.
> 
> **Overview**
> Updates `run-recipe.ts` Slack notifications to be more scannable.
> 
> Success posts now include a `:white_check_mark:` + bold recipe name and quote only the first summary line, and failure escalation DMs now include a `:x:` + bold name and wrap the error message in a code block.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b296d6a3dfb4982a57a835708605cc84a0e546f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->